### PR TITLE
revision/refactoring of spatial ctv + additional packages

### DIFF
--- a/ctv/Spatial.ctv
+++ b/ctv/Spatial.ctv
@@ -2,7 +2,7 @@
   <name>Spatial</name>
   <topic>Analysis of Spatial Data</topic>
   <maintainer email="Roger.Bivand@nhh.no">Roger Bivand</maintainer>
-  <version>2018-06-02</version>
+  <version>2018-10-04</version>
 
   <info>
     <p>Base R includes many functions that can be used for reading,
@@ -42,136 +42,79 @@
     view can be roughly structured into the following topics. If you think
     that some package is missing from the list, please let me know.
     </p>
+	
+	<h2 id="classes-for-spatial-data-and-metadata">Classes for spatial data and metadata</h2>
+	
+	<p>Because many of the packages importing and using spatial data have had to include
+      objects of storing data and functions for visualising it, an initiative is in 
+	  progress to construct shared classes and plotting functions for spatial data.</p>
+	  
+	<p>Complementary initatives are ongoing to support a better handling of geographic 
+	metadata in R</p>
+	  
+	<p><strong>Spatial data - general</strong></p>
     <ul>
-
-      <li><p><b>Classes for spatial data</b>: Because many of the
-      packages importing and using spatial data have had to include
-      objects of storing data and functions for visualising it,
-      an initiative is in progress to construct shared classes
-      and plotting functions for spatial data.
-      The <pkg>sp</pkg> package is discussed in a note in
+	  <li><pkg>sp</pkg> package provides classes and methods for dealing with spatial data 
+	  and is discussed in a note in
       <a href="http://CRAN.R-project.org/doc/Rnews/Rnews_2005-2.pdf">R
-      News</a>.  
-
-      A new package called <pkg>sf</pkg> is now on CRAN, and is being
+      News</a>.</li>  
+	  <li><pkg>sf</pkg> is a new package now on CRAN, and is being
       actively developed on <github>edzer/sfr</github>,
-      providing Simple Features for R. The development of the package is
-      being supported by the R Consortium. It provides simple features access
-      for vector data, and as such is a modern implementation of parts of 
-      <pkg>sp</pkg>.
-
-      Many other packages have become dependent on the <pkg>sp</pkg>
-      classes, including <pkg>rgdal</pkg> and <pkg>maptools</pkg>. 
-      The <pkg>rgeos</pkg> package provides an interface to topology functions
-      for <pkg>sp</pkg> objects using 
-      <a href="http://trac.osgeo.org/geos/">GEOS</a>.
-      The <pkg>stplanr</pkg> provides a "SpatialLinesNetwork" class based on 
+      providing Simple Features for R, in compliance with the 
+	  <a href="http://www.opengeospatial.org/standards/sfa">OGC Simple Feature</a> standard. 
+	  The development of the package is being supported by the 
+	  <a href="https://www.r-consortium.org/">R Consortium</a>. 
+	  It provides simple features access for vector data, and as such is a 
+	  modern implementation and standardization of parts of <pkg>sp</pkg>.</li> 
+	  <li><pkg>stplanr</pkg> provides a "SpatialLinesNetwork" class based on 
       objects defined in <pkg>sp</pkg> and <pkg>igraph</pkg> that can be used 
       for routing analysis within R. Another network package is
-      <pkg>shp2graph</pkg>. The <pkg>cleangeo</pkg> may be used to 
-      inspect spatial objects, facilitate handling and reporting of topology 
-      errors and geometry validity issues. It claims to provide a geometry
-      cleaner that will fix all geometry problems, and eliminate (at least
-      reduce) the likelihood of having issues when doing spatial data
-      processing.
-      The <pkg>raster</pkg> package is a major extension of spatial data 
+      <pkg>shp2graph</pkg>.</li>
+	  <li><pkg>spacetime</pkg> package extends the shared classes defined in <pkg>sp</pkg> for 
+      spatio-temporal data (see <a href="http://www.jstatsoft.org/v51/i07">Spatio-Temporal Data in R</a>).</li>
+	  <li><pkg>Grid2Polygons</pkg> converts a  spatial object from class 
+	  SpatialGridDataFrame to SpatialPolygonsDataFrame.</li>
+	  <li><pkg>maptools</pkg> provides conversion functions between
+      <pkg>PBSmapping</pkg> and <pkg>spatstat</pkg> and sp classes,
+      in addition to <pkg>maps</pkg> databases and sp classes.</li>
+	</ul>
+	  
+	<p><strong>Raster data</strong></p>
+	<ul>
+      <li><pkg>raster</pkg> package is a major extension of spatial data 
       classes to virtualise access to large rasters, permitting large 
       objects to be analysed, and extending the analytical tools available 
       for both raster and vector data. Used with <pkg>rasterVis</pkg>, it
-      can also provide enhanced visualisation and interaction. The 
-      <pkg>spatial.tools</pkg> package contains spatial functions meant to 
+      can also provide enhanced visualisation and interaction. </li>
+      <li><pkg>spatial.tools</pkg> package contains spatial functions meant to 
       enhance the core functionality of the <pkg>raster</pkg> package, 
-      including a parallel processing engine for use with rasters.
-      The <pkg>micromap</pkg> package provides linked micromaps using
-      ggplot2. The <pkg>recmap</pkg> package provides rectangular 
-      cartograms with rectangle sizes reflecting for example population; the 
-      <pkg>statebins</pkg> provides a simpler binning approach to US states.
-      The <pkg>spacetime</pkg> package 
-      extends the shared classes defined in <pkg>sp</pkg> for 
-      spatio-temporal data (see <a href="http://www.jstatsoft.org/v51/i07">Spatio-Temporal Data in R</a>). The <pkg>Grid2Polygons</pkg> converts a 
-      spatial object from class SpatialGridDataFrame to 
-      SpatialPolygonsDataFrame.</p>
-
-      <p>An
-      alternative approach to some of these issues is implemented in
-      the <pkg>PBSmapping</pkg> package; <pkg>PBSmodelling</pkg> provides
-      modelling support. In addition, <pkg>GEOmap</pkg> provides mapping
-      facilities directed to meet the needs of geologists, and uses the
-      <pkg>geomapdata</pkg> package.</p>
-      </li>
-
-      <li><p><b>Handling spatial data</b>: A number of packages have
-      been written using sp classes. The <pkg>raster</pkg> package 
-      introduces many GIS methods that now permit much to be done with 
-      spatial data without having to use GIS in addition to R. It may be
-      complemented by <pkg>gdistance</pkg>, which provided calculation
-      of distances and routes on geographic grids. <pkg>geosphere</pkg>
-      permits computations of distance and area 
-      to be carried out on spatial data in geographical coordinates. 
-      The <pkg>spsurvey</pkg> package provides a
-      range of sampling functions. The <pkg>trip</pkg> package extends sp
-      classes to permit the accessing and manipulating of spatial data for
-      animal tracking.
-      <pkg>spcosa</pkg> provides spatial coverage
-      sampling and random sampling from compact geographical strata. 
-      The <pkg>magclass</pkg> offers a data class for increased
-      interoperability working with spatial-temporal data together with
-      corresponding functions and methods (conversions, basic calculations
-      and basic data manipulation). The class distinguishes between spatial,
-      temporal and other dimensions to facilitate the development and
-      interoperability of tools build for it. Additional features are
-      name-based addressing of data and internal consistency checks (e.g.
-      checking for the right data order in calculations).</p>
-
-      <p>The UScensus2000 suite of packages (<pkg>UScensus2000cdp</pkg>, <pkg>UScensus2000tract</pkg>) makes the
-      use of data from the 2000 US Census more convenient. An important
-      data set, Guerry's "Moral Statistics of France", has been made
-      available in the <pkg>Guerry</pkg> package, which provides data
-      and maps and examples designed to contribute to the integration
-      of multivariate and spatial analysis.
-      The <pkg>marmap</pkg> package is designed for downloading, plotting
-      and manipulating bathymetric and topographic data in R. <pkg>marmap</pkg>
-      can query the ETOPO1 bathymetry and topography database hosted by the
-      NOAA, use simple latitude-longitude-depth data in ascii format, and take
-      advantage of the advanced plotting tools available in R to build
-      publication-quality bathymetric maps (see the <a href="http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0073051">PLOS</a>
-      paper). Modern country boundaries are
-      provided at 2 resolutions by <pkg>rworldmap</pkg> along with
-      functions to join and map tabular data referenced by country
-      names or codes. Chloropleth and bubble maps are supported and general
-      functions to work on user supplied maps (see <a href="http://journal.r-project.org/archive/2011-1/RJournal_2011-1_South.pdf">A New R package for Mapping Global Data</a>. Higher resolution country
-      borders are available from the linked package <pkg>rworldxtra</pkg>.
-      Historical country boundaries (1946-2012) can be obtained from the
-      <pkg>cshapes</pkg> package along with functions for calculating
-      distance matrices (see <a href="http://journal.r-project.org/archive/2010-1/RJournal_2010-1_Weidmann+Skrede~Gleditsch.pdf">Mapping and Measuring Country Shapes</a>).</p>
-      <p>The <pkg>landsat</pkg> package with accompanying 
-      <a href="http://www.jstatsoft.org/v43/i04">JSS paper</a> provides
-      tools for exploring and developing correction tools for remote
-      sensing data. <pkg>taRifx</pkg> is a collection of utility and 
-      convenience functions, and some interesting spatial functions.
-      The <pkg>gdalUtils</pkg> package provides wrappers for the Geospatial
-      Data Abstraction Library (GDAL) Utilities.</p> 
-
-      <p>An rOpenSci
-      <a href="http://ropensci.org/blog/blog/2016/11/22/geospatial-suite">
-      blog entry</a> described a GeoJSON-centred approach to reading GeoJSON
-      and WKT data. GeoJSON can be written and read using <pkg>rgdal</pkg>, and
-      WKT by <pkg>rgeos</pkg>. The entry lists <pkg>geojson</pkg>,
-      <pkg>geojsonio</pkg>, <pkg>geoaxe</pkg> and <pkg>lawn</pkg> among
-      others. The <pkg>rgbif</pkg> package is used to access Global
-      Biodiversity Information Facility (GBIF) data). The <pkg>geoaxe</pkg>
-      allows users to split 'geospatial' objects into pieces. The 
-      <pkg>lawn</pkg> package is a client for 'Turfjs' for 'geospatial'
-      analysis.</p></li>
-
-      <li><p><b>Reading and writing spatial data - <pkg>rgdal</pkg></b>:
-      Maps may be
-      vector-based or raster-based. The <pkg>rgdal</pkg> package provides
-      bindings to <a href="http://www.gdal.org/">GDAL</a>-supported raster
+      including a parallel processing engine for use with rasters.</li>
+	</ul>
+	
+	<p><strong>Geographic metadata</strong></p>
+	<ul>
+		<li><pkg>geometa</pkg> provides classes and methods to write geographic
+		metadata following the ISO and OGC metadata standards (ISO 19115, 19110,
+		19119) and export it as XML (ISO 19139) for later publication into 
+		metadata catalogues. Reverserly, geometa provides a way to read ISO 19139
+		metadata into R. The package extends <pkg>sf</pkg> to provide GML (ISO 19136)
+		representation of geometries. geometa is under active development on 
+		<github>eblondel/geometa</github></li>
+		<li><pkg>ncdf4</pkg> provides read and write functions for handling metadata
+		(CF conventions) in the self-described NetXDF format.</li>
+	</ul>
+	  
+	<h2 id="reading-and-writing-spatial-data">Reading and writing spatial data</h2>   
+	  
+	<p><strong>Reading and writing spatial data - <pkg>rgdal</pkg></strong></p>
+	
+      <p>Maps may be vector-based or raster-based. The <pkg>rgdal</pkg> package provides
+      bindings to <a href="http://www.gdal.org/">GDAL (Geospatial Data Abstraction Library)</a>-supported raster
       formats and <a href="http://www.gdal.org/ogr/">OGR</a>-supported
-      vector formats. It contains functions to write raster
-      files in supported formats. The package also provides <a
-      href="http://trac.osgeo.org/proj/">PROJ.4</a> projection
+      vector formats. It contains functions to write raster files in supported formats. Formats 
+	  supported by GDAL/OGR include both OGC standard  data formats (e.g. GeoJSON) and 
+	  proprietary formats (e.g. ESRI Shapefile).
+	  The package also provides <a href="http://trac.osgeo.org/proj/">PROJ.4</a> projection
       support for vector objects 
       (<a href="http://spatialreference.org">this site</a> provides 
       searchable online PROJ.4 representations of projections). 
@@ -180,91 +123,253 @@
       The Windows and Mac OSX CRAN binaries of <pkg>rgdal</pkg>
       include subsets of possible data source drivers; if others
       are needed, use other conversion utilities, or install from source
-      against a version of GDAL with the required drivers. 
-      The <pkg>rgeos</pkg> package provides functions for 
-      reading and writing well-known text (WKT) geometry, and the 
-      <pkg>wkb</pkg> package provides functions for reading and writing 
-      well-known binary (WKB) geometry.</p></li>
+      against a version of GDAL with the required drivers.</p>
+	  	  
+	<p><strong> Reading and writing spatial data - data formats</strong></p>
 
-      <li><p><b>Reading and writing spatial data - other packages</b>:
-      There are a
-      number of other packages for accessing vector data on CRAN:
-      <pkg>maps</pkg> (with <pkg>mapdata</pkg> and <pkg>mapproj</pkg>)
+	<p>Other packages provide facilities to read and write spatial data, dealing
+	with open standard formats or proprietary formats.</p>
+	
+	<p><em>OGC Standard Data formats</em></p>
+	<ul>
+		<li><em>Well-Known Text (WKT) / Well-Known Binary (WKB):</em> These standards are
+		part of the OGC Simple Feature specification. The <pkg>rgeos</pkg> 
+		package provides functions for reading and writing well-known text (WKT) geometry. 
+		Package <pkg>wkb</pkg> package provides functions for reading and writing well-known 
+		binary (WKB) geometry. Both WKT/WKB formats are supported by <pkg>sf</pkg> package that
+		implements the whole OGC Simple Feature specification in R.</li>
+		<li><em>GeoJSON:</em> An rOpenSci
+		<a href="http://ropensci.org/blog/blog/2016/11/22/geospatial-suite">
+		blog entry</a> described a GeoJSON-centred approach to reading GeoJSON
+		and WKT data. GeoJSON can be written and read using <pkg>rgdal</pkg>, and
+		WKT by <pkg>rgeos</pkg>. The entry lists <pkg>geojson</pkg>,
+		<pkg>geojsonio</pkg>, <pkg>geoaxe</pkg> and <pkg>lawn</pkg> among
+		others.</li>
+		<li><em>Geographic Markup Language (GML):</em>GML format can be read and writen with
+		<pkg>rgdal</pkg>. Additional GML native reader and writer is provided by <pkg>geometa</pkg> 
+		model with bindings to the <pkg>sf</pkg> classes, for extension of geographic 
+		metadata with GML data and metadata elements (GML 3.2.1 and 3.3) and interfacing OGC 
+		web-services in <pkg>ows4R</pkg> package</li>
+		<li><em>NetCDF files:</em> <pkg>ncdf4</pkg> or <pkg>RNetCDF</pkg> may be used.</li>
+	</ul>
+	
+	<p><em>Proprietary Data Formats</em></p>
+	<ul>
+	  <li><em>ESRI formats:</em> <pkg>maps</pkg> (with <pkg>mapdata</pkg> and <pkg>mapproj</pkg>)
       provides access to the same kinds of geographical databases as S -
       <pkg>RArcInfo</pkg> allows ArcInfo v.7 binary files and *.e00
       files to be read, and <pkg>maptools</pkg> and <pkg>shapefiles</pkg>
-      read and write ArcGIS/ArcView shapefiles; for NetCDF files,
-      <pkg>ncdf4</pkg> or <pkg>RNetCDF</pkg> may be used.
-      The <pkg>maptools</pkg>
-      package also provides helper functions for writing map polygon
-      files to be read by WinBUGS, Mondrian, and the tmap command
-      in Stata. It also provides interface functions between
-      <pkg>PBSmapping</pkg> and <pkg>spatstat</pkg> and sp classes,
-      in addition to <pkg>maps</pkg> databases and sp classes. There is
-      also an interface to GSHHS shoreline databases. The <pkg>gmt</pkg> 
-      package gives a simple interface between GMT
-      map-making software and R. <pkg>geonames</pkg> is an interface to 
-      the <a href="http://www.geonames.org/">www.geonames.org</a> service.
-      <pkg>OpenStreetMap</pkg> gives access to open street map raster images, 
-      and <pkg>osmar</pkg> provides infrastructure to access OpenStreetMap 
-      data from different sources, to work with the data in common R manner, 
-      and to convert data into available infrastructure provided by 
-      existing R packages.</p>
-
-      <p>The <pkg>rpostgis</pkg> package provides additional functions to the
-      'RPostgreSQL' package to interface R with a 'PostGIS'-enabled database,
-      as well as convenient wrappers to common 'PostgreSQL' queries. The
-      <pkg>postGIStools</pkg> package provides functions to convert geometry
-      and 'hstore' data types from 'PostgreSQL' into standard R objects,
-      as well as to simplify the import of R data frames (including spatial
-      data frames) into 'PostgreSQL'</p>
-
-      <p>Integration with version 6.* and of the leading open source
+      read and write ESRI ArcGIS/ArcView shapefiles.</li>
+	  <li><em>Others:</em> <pkg>maptools</pkg>
+      package provides helper functions for writing map polygon
+      files to be read by <em>WinBUGS</em>, <em>Mondrian</em>, and the tmap command
+      in <em>Stata</em>. The <pkg>gmt</pkg> package gives a simple interface between GMT
+      map-making software and R.</li>
+	</ul>
+	
+	<p><strong>Reading and writing spatial data - GIS Software connectors</strong></p>
+	
+	<ul>
+	  <li><em>PostGIS:</em> The <pkg>rpostgis</pkg> package provides additional 
+	  functions to the <pkg>RPostgreSQL</pkg> package to interface R with 
+	  a 'PostGIS'-enabled database, as well as convenient wrappers to common 
+	  'PostgreSQL' queries.<pkg>postGIStools</pkg> package provides functions 
+	  to convert geometry and 'hstore' data types from 'PostgreSQL' into standard 
+	  R objects, as well as to simplify the import of R data frames (including spatial
+      data frames) into 'PostgreSQL'. <pkg>sf</pkg> also provides an R interface to 
+	  Postgis, for both reading and writing, throuh GDAL.</li>
+      <li><em>GRASS:</em>Integration with version 6.* and of the leading open source
       GIS, GRASS, is provided in CRAN package <pkg>spgrass6</pkg>, using
       <pkg>rgdal</pkg> for exchanging data. 
-      For GRASS 7.*, use <pkg>rgrass7</pkg>. <pkg>RPyGeo</pkg> is a wrapper
-      for Python access to the ArcGIS GeoProcessor, and <pkg>RSAGA</pkg>
-      is a similar shell-based wrapper for SAGA commands. The <pkg>RQGIS</pkg>
+      For GRASS 7.*, use <pkg>rgrass7</pkg>.</li>
+	  <li><em>SAGA:</em><pkg>RSAGA</pkg> is a similar shell-based wrapper for SAGA commands.</li>
+	  <li><em>Quantum GIS (QGIS):</em><pkg>RQGIS</pkg>
       package establishes an interface between R and QGIS, i.e. it allows
       the user to access QGIS functionalities from the R console. It achieves
       this by using the QGIS Python API via the command line. Note also
-      <a href="https://stat.ethz.ch/pipermail/r-sig-geo/2016-August/024817.html">this thread</a> on an alternative R/QGIS integration.</p></li>
+      <a href="https://stat.ethz.ch/pipermail/r-sig-geo/2016-August/024817.html">this thread</a> on an alternative R/QGIS integration.</li>
+	  <li><em>ArcGIS:</em><pkg>RPyGeo</pkg> is a wrapper
+      for Python access to the ArcGIS GeoProcessor</li>
+	</ul>
+	  
+	<p><strong>Interfaces to Spatial Web-Services</strong></p>
 
-     <li><p><b>Visualisation</b>:
-      For visualization, the colour palettes provided in
-      the <pkg>RColorBrewer</pkg> package are very useful, and may
+	<p>Some R packages focused on providing interfaces to web-services and web tools in support of 
+	spatial data management. Here follows a first tentative (non-exhaustive) list:</p>
+	
+	<ul>
+		<li><pkg>ows4R</pkg> is a new package that intends to provide an R interface 
+		to OGC standard Web-Services. It is in active development at <github>eblondel/ows4R</github> 
+		and currently support interfaces to the Web Feature Service (WFS) for vector data access, 
+		with binding to the <pkg>sf</pkg> package, and the Catalogue Service (CSW) for geographic 
+		metadata discovery and management (including transactions), with binding to the <pkg>geometa</pkg>
+		package.
+		</li>
+		<li><pkg>geosapi</pkg> is an R client for the <a href="http://geoserver.org">GeoServer</a> REST API, 
+		an open source implementation used widely for serving spatial data.</li>
+		<li><pkg>geonapi</pkg> provides an interface to the <a href="https://geonetwork-opensource.org/">GeoNetwork</a> 
+		legacy API, an opensource catalogue for managing geographic metadata.</li>
+	</ul>
+
+	<p><strong>Specific geospatial data sources of interest</strong></p>
+	
+	<ul>
+	  <li>Modern country boundaries are
+      provided at 2 resolutions by <pkg>rworldmap</pkg> along with
+      functions to join and map tabular data referenced by country
+      names or codes. Chloropleth and bubble maps are supported and general
+      functions to work on user supplied maps (see <a href="http://journal.r-project.org/archive/2011-1/RJournal_2011-1_South.pdf">A New R package for Mapping Global Data</a>. Higher resolution country
+      borders are available from the linked package <pkg>rworldxtra</pkg>.
+      Historical country boundaries (1946-2012) can be obtained from the <pkg>cshapes</pkg>.</li> 
+	  <li><pkg>marmap</pkg> package is designed for downloading, plotting 
+	  and manipulating bathymetric and topographic data in R. It allows to
+      query the ETOPO1 bathymetry and topography database hosted by the
+      NOAA, use simple latitude-longitude-depth data in ascii format, and take
+      advantage of the advanced plotting tools available in R to build
+      publication-quality bathymetric maps (see the <a href="http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0073051">PLOS</a>
+      paper).</li>
+	  <li><pkg>maptools</pkg> provides an interface to GSHHS shoreline databases.</li>
+	  <li>The UScensus2000 suite of packages (<pkg>UScensus2000cdp</pkg>, <pkg>UScensus2000tract</pkg>) makes the
+      use of data from the 2000 US Census more convenient. An important
+      data set, Guerry's "Moral Statistics of France", has been made
+      available in the <pkg>Guerry</pkg> package, which provides data
+      and maps and examples designed to contribute to the integration
+      of multivariate and spatial analysis.</li>
+	  <li><pkg>rgbif</pkg> package is used to access Global
+      Biodiversity Information Facility (GBIF) occurence data</li>
+	  <li><pkg>geonames</pkg> is an interface to 
+      the <a href="http://www.geonames.org/">www.geonames.org</a> service.</li>
+	  <li><pkg>OpenStreetMap</pkg> gives access to open street map raster images, 
+      and <pkg>osmar</pkg> provides infrastructure to access OpenStreetMap 
+      data from different sources, to work with the data in common R manner, 
+      and to convert data into available infrastructure provided by 
+      existing R packages.</li>
+	</ul>
+	
+	<h2 id="handling-spatial-data">Handling spatial data</h2>  
+	  
+	<p>A number of packages dedicated to spatial data handling have be written
+	using sp classes.</p>
+
+	<p><strong>Data processing - general</strong></p>	
+	<ul>
+	  <li><pkg>rgdal</pkg> and <pkg>maptools</pkg>. 
+      The <pkg>rgeos</pkg> package provides an interface to topology functions
+      for <pkg>sp</pkg> objects using  <a href="http://trac.osgeo.org/geos/">GEOS</a>.</li>
+	  <li><pkg>raster</pkg> package 
+      introduces many GIS methods that now permit much to be done with 
+      spatial data without having to use GIS in addition to R.</li>
+	  <li>The <pkg>gdalUtils</pkg> package provides wrappers for the Geospatial
+      Data Abstraction Library (GDAL) Utilities.</li> 
+	  <li><pkg>gdistance</pkg>, provides functions to calculate
+      distances and routes on geographic grids. <pkg>geosphere</pkg>
+      permits computations of distance and area 
+      to be carried out on spatial data in geographical coordinates. 
+	  <pkg>cshapes</pkg> package provides functions for calculating
+      distance matrices (see <a href="http://journal.r-project.org/archive/2010-1/RJournal_2010-1_Weidmann+Skrede~Gleditsch.pdf">Mapping and Measuring Country Shapes</a>).</li> 	  
+      <li><pkg>spsurvey</pkg> provides a range of sampling functions.</li>
+	  <li>The <pkg>trip</pkg> package extends sp
+      classes to permit the accessing and manipulating of spatial data for
+      animal tracking.</li>
+      <li><pkg>spcosa</pkg> provides spatial coverage
+      sampling and random sampling from compact geographical strata.</li>
+      <li><pkg>magclass</pkg> offers a data class for increased
+      interoperability working with spatial-temporal data together with
+      corresponding functions and methods (conversions, basic calculations
+      and basic data manipulation). The class distinguishes between spatial,
+      temporal and other dimensions to facilitate the development and
+      interoperability of tools build for it. Additional features are
+      name-based addressing of data and internal consistency checks (e.g.
+      checking for the right data order in calculations).</li>
+	  <li><pkg>taRifx</pkg> is a collection of utility and 
+      convenience functions, and some interesting spatial functions.</li>
+	  <li><pkg>geoaxe</pkg>allows users to split 'geospatial' objects into pieces.</li>
+	  <li>The <pkg>lawn</pkg> package is a client for 'Turfjs' for 'geospatial'analysis.</li>
+    </ul>	  
+	    
+	<p><strong>Data processing - raster and imagery data</strong></p>	
+	<ul>
+	  <li>The <pkg>landsat</pkg> package with accompanying 
+      <a href="http://www.jstatsoft.org/v43/i04">JSS paper</a> provides
+      tools for exploring and developing correction tools for remote
+      sensing data.</li>
+	</ul>
+
+	<p><strong>Data cleaning</strong></p>
+	<ul>
+	  <li><pkg>cleangeo</pkg> may be used to 
+      inspect spatial objects, facilitate handling and reporting of topology 
+      errors and geometry validity issues. It may be used to reduce the likelihood 
+	  of having issues when doing spatial data processing.</li>
+	</ul>
+	  
+	<h2 id="visualizing-spatial-data">Visualizing spatial data</h2>     
+	
+	<p><strong>Base visualization packages</strong></p>
+	<ul>
+	  <li>Packages such as <pkg>sp</pkg>, <pkg>sf</pkg>, <pkg>raster</pkg> and <pkg>rasterVis</pkg>
+	  provide basic visualization methods through the generic plot function</li>
+	  <li><pkg>RColorBrewer</pkg> provides very useful colour palettes that may
       be modified or extended using the <code>colorRampPalette</code>
-      function provided with R. The <pkg>classInt</pkg> package provides
-      functions for choosing class intervals for thematic cartography.
-      The <pkg>tmap</pkg> package provides a modern basis for thematic mapping
+      function provided with R.</li>
+	  <li><pkg>classInt</pkg> package provides
+      functions for choosing class intervals for thematic cartography.</li>
+	</ul>
+	
+	<p><strong>Thematic cartography packages</strong></p>
+	<ul>
+	  <li><pkg>tmap</pkg> package provides a modern basis for thematic mapping
       optionally using a Grammar of Graphics syntax. Because it has a custom
       grid graphics platform, it obviates the need to fortify geometries to 
-      use with ggplot2. The <pkg>mapview</pkg> package provides methods to
-      view spatial objects interactively, usually on a web mapping base; the
-      <pkg>leaflet</pkg> is another alternative.
-      The <pkg>quickmapr</pkg> package
+      use with ggplot2.</li>
+	  <li><pkg>quickmapr</pkg>
       provides a simple method to visualize 'sp' and 'raster' objects,
       allows for basic zooming, panning, identifying, and labeling of
       spatial objects, and does not require that the data be in geographic
-      coordinates. The <pkg>cartography</pkg> package allows various
+      coordinates.</li>
+	  <li><pkg>cartography</pkg> package allows various
       cartographic representations such as proportional symbols,
-      choropleth, typology, flows or discontinuities. The <pkg>mapmisc</pkg>
+      choropleth, typology, flows or discontinuities.</li>
+	  <li>The <pkg>mapmisc</pkg>
       package is a minimal, light-weight set of tools for producing nice
-      looking maps in R, with support for map projections.If the
-      user wishes to place a map backdrop behind other displays, the the
-      <pkg>RgoogleMaps</pkg> package for accessing 
-      Google Maps(TM) may be useful. <pkg>ggmap</pkg> may be used for 
-      spatial visualisation with Google Maps and OpenStreetMap; <pkg>ggsn</pkg>
-      provides North arrows and scales for such maps.
-      The <pkg>plotGoogleMaps</pkg> package provides methods for the 
+      looking maps in R, with support for map projections.</li>
+	  <li>Additional processing and mapping functions are available in <pkg>PBSmapping</pkg> package; 
+	  <pkg>PBSmodelling</pkg> provides modelling support. In addition, <pkg>GEOmap</pkg> 
+	  provides mapping facilities directed to meet the needs of geologists, and uses the
+      <pkg>geomapdata</pkg> package.</li>
+	</ul>
+	
+	<p><strong>Packages based on web-mapping frameworks</strong></p>	
+	<ul>
+	  <li><pkg>mapview</pkg>, <pkg>leaflet</pkg> and <pkg>leafletR</pkg> packages provide methods to
+      view spatial objects interactively, usually on a web mapping base.</li>
+	  <li><pkg>RgoogleMaps</pkg> package for accessing 
+      Google Maps(TM) may be useful if the user wishes to place a map backdrop 
+	  behind other displays.</li>
+	  <li><pkg>plotGoogleMaps</pkg> package provides methods for the 
       visualisation of spatial and spatio-temporal objects in Google Maps in
-      a web browser. <pkg>plotKML</pkg> is a package providing methods for
+      a web browser.</li>
+	  <li><pkg>plotKML</pkg> is a package providing methods for
       the visualisation of spatial and spatio-temporal objects in Google
-      Earth. A further option is <pkg>leafletR</pkg>, which provides basic
-      web-mapping functionality to combine vector data files and online
-      map tiles from different sources.</p></li>
-
-      <li><p><b>Point pattern analysis</b>: The <pkg>spatial</pkg>
+      Earth.</li>
+	  <li><pkg>ggmap</pkg> may be used for spatial visualisation with Google Maps 
+	  and OpenStreetMap;<pkg>ggsn</pkg> provides North arrows and scales for such maps.</li>
+	</ul>
+	
+	<p><strong>Building Cartograms</strong></p>	
+    <ul>
+	  <li>The <pkg>micromap</pkg> package provides linked micromaps using ggplot2.</li>
+	  <li><pkg>recmap</pkg> package provides rectangular 
+      cartograms with rectangle sizes reflecting for example population.</li> 
+	  <li><pkg>statebins</pkg> provides a simpler binning approach to US states.</li>
+	</ul>
+	  
+	 
+	<h2 id="analyzing-spatial-data">Analyzing spatial data</h2>
+	
+	<p><strong>Point pattern analysis</strong></p>
+	  
+      <p>The <pkg>spatial</pkg>
       package is a recommended package shipped with base R, and contains
       several core functions, including an implementation of Khat
       by its author, Prof. Ripley. In addition, <pkg>spatstat</pkg>
@@ -306,9 +411,11 @@
       calculation. <pkg>latticeDensity</pkg> contains functions that compute
       the lattice-based density estimator of Barry and McIntyre, which
       accounts for point processes in two-dimensional regions with
-      irregular boundaries and holes.</p></li>
+      irregular boundaries and holes.</p>
 
-      <li><p><b>Geostatistics</b>: The <pkg>gstat</pkg> package
+	<p><strong>Geostatistics</strong></p>  
+	  
+      <p>The <pkg>gstat</pkg> package
       provides a wide range of functions for univariate and multivariate
       geostatistics, also for larger datasets, while <pkg>geoR</pkg>
       and <pkg>geoRglm</pkg> contain functions for model-based
@@ -399,10 +506,11 @@
       preclude interpolation with Euclidean distances.
       <pkg>RSurvey</pkg> may be used as a processing program for spatially
       distributed data, and is capable of error corrections and data
-      visualisation.</p></li>
+      visualisation.</p>
 
-      <li><p><b>Disease mapping and areal data analysis</b>:
-      <pkg>DCluster</pkg> is a package for the detection of
+	<p><strong>Disease mapping and areal data analysis</strong></p>  
+	  
+      <p><pkg>DCluster</pkg> is a package for the detection of
       spatial clusters of diseases. It extends and  depends on the
       <pkg>spdep</pkg> package, which provides basic functions for
       building neighbour lists and spatial weights, tests for spatial
@@ -474,10 +582,11 @@
       forward stepwise regression, incremental forward stagewise regression,
       least angle regression (LARS), and lasso models for selecting the
       spatial scale of covariates in regression models.
-      </p></li>
+      </p>
 
-      <li><p><b>Spatial regression</b>:
-      The choice of function for spatial regression will depend on the 
+	<p><strong>Spatial regression</strong></p>   
+	  
+      <p>The choice of function for spatial regression will depend on the 
       support available. If the data are characterised by point support
       and the spatial process is continuous, geostatistical methods may be 
       used, or functions in the <pkg>nlme</pkg> package. If the support
@@ -519,52 +628,56 @@
       (SAR) and spatial error (SEM) probit models are included. The
       <pkg>starma</pkg> package provides functions to identify, estimate
       and diagnose a Space-Time AutoRegressive Moving Average (STARMA)
-      model.</p></li>
+      model.</p>
 
-      <li><p><b>Ecological analysis</b>: There are many packages
-      for analysing ecological and environmental data. They include
-      <pkg>ade4</pkg> for exploratory and Euclidean methods in the
+	<p><strong>Ecological analysis</strong></p>
+	  
+    <p>There are many packages for analysing ecological and environmental data. They include:</p>
+	  
+	<ul>
+      <li><pkg>ade4</pkg> for exploratory and Euclidean methods in the
       environmental sciences,  the adehabitat family of packages 
       for the analysis of habitat selection by animals
       (<pkg>adehabitatHR</pkg>, <pkg>adehabitatHS</pkg>,
-      <pkg>adehabitatLT</pkg>, and <pkg>adehabitatMA</pkg>),
-      <pkg>pastecs</pkg> for the
-      regulation, decomposition and analysis of space-time series,
-      <pkg>vegan</pkg> for ordination methods and other useful
+      <pkg>adehabitatLT</pkg>, and <pkg>adehabitatMA</pkg>)</li>
+      <li><pkg>pastecs</pkg> for the
+      regulation, decomposition and analysis of space-time series</li>
+      <li><pkg>vegan</pkg> for ordination methods and other useful
       functions for community and vegetation ecologists, and many
       other functions in other contributed packages. One such is
       <pkg>tripEstimation</pkg>, basing on the classes provided by
       <pkg>trip</pkg>. <pkg>ncf</pkg> has entered CRAN recently, and
-      provides a range of spatial nonparametric covariance functions.
-      The <pkg>spind</pkg> package provides functions for spatial methods
+      provides a range of spatial nonparametric covariance functions.</li>
+      <li>The <pkg>spind</pkg> package provides functions for spatial methods
       based on generalized estimating equations (GEE) and wavelet-revised
       methods (WRM), functions for scaling by wavelet multiresolution
       regression (WMRR), conducting multi-model inference, and stepwise model
-      selection.
-      <pkg>rangeMapper</pkg> is a package to manipulate species range
+      selection.</li>
+      <li><pkg>rangeMapper</pkg> is a package to manipulate species range
       (extent-of-occurrence) maps, mainly tools for easy generation of
-      biodiversity (species richness) or life-history traits maps. The
-      <pkg>siplab</pkg> package is a platform for experimenting with
-      spatially explicit individual-based vegetation models.
-      <pkg>ModelMap</pkg> builds on other packages to create models
-      using underlying GIS data. The <pkg>SpatialPosition</pkg> computes
+      biodiversity (species richness) or life-history traits maps.</li>
+	  <li>The <pkg>siplab</pkg> package is a platform for experimenting with
+      spatially explicit individual-based vegetation models.</li>
+      <li><pkg>ModelMap</pkg> builds on other packages to create models
+      using underlying GIS data.</li>
+	  <li>The <pkg>SpatialPosition</pkg> computes
       spatial position models: Stewart potentials, Reilly catchment areas,
-      Huff catchment areas. The <pkg>Watersheds</pkg> package provides
+      Huff catchment areas. </li>
+	  <li>The <pkg>Watersheds</pkg> package provides
       methods for watersheds aggregation and spatial drainage network
-      analysis.
-
-      An off-CRAN package
-      - <a href="http://www.leg.ufpr.br/Rcitrus/">Rcitrus</a> - is for
-      the spatial analysis of plant disease incidence.
-      The <pkg>ngspatial</pkg> package 
+      analysis.</li>
+	  <li><a href="http://www.leg.ufpr.br/Rcitrus/">Rcitrus</a> (off-CRAN package)
+	  is for the spatial analysis of plant disease incidence.</li>
+      <li>The <pkg>ngspatial</pkg> package 
       provides tools for analyzing spatial data, especially non-Gaussian 
       areal data. It supports the sparse spatial generalized linear mixed 
       model of Hughes and Haran (2013) and the centered autologistic model 
-      of Caragea and Kaiser (2009).
-      The <a href="Environmetrics.html">Environmetrics</a> Task
-      View contains a much more complete survey of relevant functions
-      and packages.</p></li>
+      of Caragea and Kaiser (2009).</li>
     </ul>
+	
+	<p>The <a href="Environmetrics.html">Environmetrics</a> Task View contains 
+	a much more complete survey of relevant functions and packages.</p>
+	
   </info>
 
   <packagelist>
@@ -604,10 +717,13 @@
     <pkg>geojsonio</pkg>
     <pkg>GEOmap</pkg>
     <pkg>geomapdata</pkg>
+	<pkg>geometa</pkg>
     <pkg>geonames</pkg>
     <pkg>georob</pkg>
     <pkg priority="core">geoR</pkg>
     <pkg>geoRglm</pkg>
+	<pkg>geonapi</pkg>
+	<pkg>geosapi</pkg>
     <pkg>geospacom</pkg>
     <pkg>geosphere</pkg>
     <pkg>geospt</pkg>
@@ -652,6 +768,7 @@
     <pkg>OasisR</pkg>
     <pkg>OpenStreetMap</pkg>
     <pkg>osmar</pkg>
+	<pkg>ows4R</pkg>
     <pkg>PBSmapping</pkg>
     <pkg>PBSmodelling</pkg>
     <pkg>plotGoogleMaps</pkg>


### PR DESCRIPTION
Dear @rsbivand ,

Following our email exchange, see here a 1st revision/refactoring of the CRAN Spatial task view for your review. The pull request covers 2 things:
1. a refreshing proposal for the task view, in order to categorize further the items, with the aim to facilitate access for users by category of packages.
2. addition of 4 packages i've created and maintain on CRAN (my initial request when I contacted you): 
* [geosapi](https://github.com/eblondel/geosapi): R interface to the GeoServer REST API
* [geonapi](https://github.com/eblondel/geonapi): R interface to the GeoNetwork legacy API
* [geometa](https://github.com/eblondel/geometa): Tools to read and write ISO/OGCgeographic metadata, and
* [ows4R](https://github.com/eblondel/ows4R): R Interface to OGC Web-Services

The refactoring first handles a reshape of the layout of the main categories, handling header html elements for better visibility. Only slight modifications were provided to the main categoris titles, and further sub-categories and sections were added.

* the 1st one is extended to metadata: ``Classes for spatial data and metadata``; and subsections: spatial vector data, spatial raster data, geographic metadata (with ``geometa`` but also ``ncf4`` for support of self-described NetCDF-CF Conventions.

* `` Read and Write Spatial data`` (put before - ``Handling spatial data``), and splitted into subsections. The first one deserves to be kept, targeting rgdal: ``Reading and writing spatial data - rgdal``. I've then refactored the other content to be clustered into the following sub-categories:
-- ``Read and Write Spatial data - data formats``, where i've highlighted 2 sub-sections: one on ``open OGC standards`` (that IMHO deserves to be highlighted), and another on ``proprietary formats`` (including ESRI Shapefile).
-- ``Read and Write Spatial data - Software connectors`` (with PostGis, QGIS, SAGA, GRASS etc)
-- ``Read and Write Spatial data - Interfaces to Spatial Web-Services``: this is new in the spatial task view, and where i've added my contributed packages ``geosapi``, ``geonapi`` and ``ows4R``
-- All datasource-related packages were listed under a sub-category ``Specific geospatial data sources of interest`` where there is probably room for improvement.

* ``Handling Spatial Data`` has also been sub-sectioned to reflect ``general data processing`` packages, ``raster processing``, ``data cleaning``

* ``Visualisation`` --> ``Visualizing spatial data`` where subcategories were added: common tools for visualization, thematic cartography packages, packages based on web-mapping frameworks (leaflet, google maps, etc), and cartograms creation.

* The different categories for analysis were clustered in a parent category "Analyzing spatial data". I didn't touch at all to the categories ``point pattern analysis``, ``geostatistics`` and ``Disease mapping and areal data analysis``, mainly because I don't know the different packages, and how they could be eventually clustered into subsections and less paragraph-based.

I'm aware that this proposal is far from being perfect, but I hope it could be a 1st iteration to refresh and improve the Spatial task view. Of course, your comments are welcome, and I will be keen on helping further to improve and maintain the view.

FYI: I've ensured that the command for transforming to html was working fine (no tags error), and made a final text review based on the created HTML.

Looking forward to your feedback

Best regards
Emmanuel