### PR TITLE
Added packages and descriptions, fixed sf url

### DIFF
--- a/Spatial.html
+++ b/Spatial.html
@@ -1,0 +1,1750 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CRAN Task View: Analysis of Spatial Data</title>
+  <link rel="stylesheet" type="text/css" href="../CRAN_web.css" />
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <meta name="citation_title" content="CRAN Task View: Analysis of Spatial Data" />
+  <meta name="citation_author" content="Roger Bivand" />
+  <meta name="citation_publication_date" content="2018-12-23" />
+  <meta name="citation_public_url" content="https://CRAN.R-project.org/view=Spatial" />
+  <meta name="DC.title" content="CRAN Task View: Analysis of Spatial Data" />
+  <meta name="DC.creator" content="Roger Bivand" />
+  <meta name="DC.issued" content="2018-12-23" />
+  <meta name="DC.identifier" content="https://CRAN.R-project.org/view=Spatial" />
+</head>
+
+<body>
+  <h2>CRAN Task View: Analysis of Spatial Data</h2>
+  <table summary="Spatial task view information">
+    <tr><td valign="top"><b>Maintainer:</b></td><td>Roger Bivand</td></tr>
+    <tr><td valign="top"><b>Contact:</b></td><td>&#x52;&#x6f;&#x67;&#x65;&#x72;&#x2e;&#x42;&#x69;&#x76;&#x61;&#x6e;&#x64;&#x20;&#x61;&#x74;&#x20;&#x6e;&#x68;&#x68;&#x2e;&#x6e;&#x6f;</td></tr>
+    <tr><td valign="top"><b>Version:</b></td><td>2018-12-23</td></tr>
+    <tr><td valign="top"><b>URL:</b></td><td><a href="https://CRAN.R-project.org/view=Spatial">https://CRAN.R-project.org/view=Spatial</a></td></tr>
+  </table>
+
+    <div>
+      <p>
+        Base R includes many functions that can be used for reading,
+    visualising, and analysing spatial data. The focus in this view is on
+    &quot;geographical&quot; spatial data, where observations can be identified
+    with geographical locations, and where additional information about
+    these locations may be retrieved if the location is recorded with
+    care.
+        <p>
+          Base R functions are complemented by contributed packages,
+    some of which are on CRAN, and others are still in development.
+    One location is
+          <a href="https://github.com/">
+            Github
+          </a>. Some key packages
+    including
+<a href="../packages/sf/index.html">sf</a>
+          and
+<a href="../packages/stars/index.html">stars</a>
+          are grouped under
+          <a href="https://github.com/r-spatial">
+            r-spatial
+          </a>, others including
+<a href="../packages/raster/index.html">raster</a>
+          under
+          <a href="https://github.com/rspatial">
+            rspatial
+          </a>.
+    Maintenance of the
+<a href="../packages/sp/index.html">sp</a>
+          is continuing here:
+<a href="https://github.com/edzer/sp/"><span class="GitHub">sp</span></a>.
+        </p>
+        Another set of locations for the development and maintenance of packages on
+        <a href="https://R-Forge.R-project.org/">
+          R-Forge
+        </a>, which lists &quot;Spatial Data and Statistics&quot; projects in its
+        <a href="https://R-Forge.R-project.org/softwaremap/trove_list.php">
+          project
+    tree
+        </a>. Information on R-spatial packages was until 2016 posted on the R-Forge rspatial project
+        <a href="https://rspatial.R-Forge.R-project.org/">
+          website
+        </a>, including
+    a visualisation gallery.
+      </p>
+      <p>
+        The contributed packages address two broad areas: moving spatial data
+    into and out of R, and analysing spatial data in R.
+      </p>
+      <p>
+        The
+        <a href="https://stat.ethz.ch/mailman/listinfo/R-SIG-Geo/">
+          R-SIG-Geo
+        </a>
+        mailing-list is a good place to begin for obtaining help
+    and discussing questions about both accessing data, and analysing it.
+    The mailing list is a good place to search for information about
+    relevant courses. Further information about courses may be found
+    under the &quot;Events&quot; tab of
+        <a href="http://r-spatial.org/">
+          this blog
+        </a>.
+      </p>
+      <p>
+        There are a number of contributed tutorials and introductions; 
+    a recent one is
+        <a href="https://cran.r-project.org/doc/contrib/intro-spatial-rl.pdf">
+          Introduction to visualising spatial data in R
+        </a>
+        by Robin Lovelace 
+    and James Cheshire.
+      </p>
+      <p>
+        The packages in this
+    view can be roughly structured into the following topics. If you think
+    that some package is missing from the list, please fork the
+        <a href="https://github.com/r-spatial/task_views">
+          task view 
+    repository
+        </a>
+        and provide a pull request in ctv format for the 
+    ctv/Spatial.ctv file.
+      </p>
+      <h2 id="classes-for-spatial-data-and-metadata">
+        Classes for spatial
+    data and metadata
+      </h2>
+      <p>
+        Because many of the packages importing and using spatial data have had
+    to include objects of storing data and functions for visualising it, an
+    initiative is in progress to construct shared classes and plotting
+    functions for spatial data.
+      </p>
+      <p>
+        Complementary initiatives are ongoing to support better handling of
+    geographic metadata in R
+      </p>
+      <p>
+        <strong>
+          Spatial data - general
+        </strong>
+      </p>
+      <ul>
+        <li>
+          The
+<a href="../packages/sp/index.html">sp</a>
+          package provides classes and methods for dealing with spatial data 
+      and is discussed in a note in
+          <a href="http://CRAN.R-project.org/doc/Rnews/Rnews_2005-2.pdf">
+            R
+      News
+          </a>.
+        </li>
+        <li>
+<a href="../packages/sf/index.html">sf</a>
+          is a newer package now on CRAN, and is being
+      actively developed here:
+<a href="https://github.com/r-spatial/sf/"><span class="GitHub">sf</span></a>,
+      providing Simple Features for R, in compliance with the
+          <a href="http://www.opengeospatial.org/standards/sfa">
+            OGC Simple Feature
+          </a>
+          standard. 
+      The development of the package is being supported by the
+          <a href="https://www.r-consortium.org/">
+            R Consortium
+          </a>. 
+      It provides simple features access for vector data, and as such is a 
+      modern implementation and standardization of parts of
+<a href="../packages/sp/index.html">sp</a>. 
+      It is documented in an
+          <a href="https://journal.r-project.org/archive/2018/RJ-2018-009/index.html">
+            R Journal
+          </a>
+          article.
+        </li>
+        <li>
+<a href="../packages/stars/index.html">stars</a>
+          is being actively  developed here:
+<a href="https://github.com/rspatial/stars/"><span class="GitHub">stars</span></a>, and supported by the
+          <a href="https://www.r-consortium.org/">
+            R Consortium
+          </a>; it
+          provides for spatiotemporal data in the form of dense arrays.
+        </li>
+        <li>
+<a href="../packages/stplanr/index.html">stplanr</a>
+          provides a &quot;SpatialLinesNetwork&quot; class based
+      on objects defined in
+<a href="../packages/sp/index.html">sp</a>
+          and
+<a href="../packages/igraph/index.html">igraph</a>
+          that can be
+      used for routing analysis within R. Another network package is
+<a href="../packages/shp2graph/index.html">shp2graph</a>.
+        </li>
+        <li>
+          The
+<a href="../packages/spacetime/index.html">spacetime</a>
+          package extends the shared classes defined in
+<a href="../packages/sp/index.html">sp</a>
+          for 
+      spatio-temporal data (see
+          <a href="http://www.jstatsoft.org/v51/i07">
+            Spatio-Temporal Data in R
+          </a>).
+        </li>
+        <li>
+          The
+<a href="../packages/rcosmo/index.html">rcosmo</a>
+          package provides simple access to spherical and HEALPix data. It extends
+      standard dataframes for HEALPix-type data.
+        </li>
+        <li>
+<a href="../packages/inlmisc/index.html">inlmisc</a>
+          has followed on from Grid2Polygons and converts a  spatial object from class 
+      SpatialGridDataFrame to SpatialPolygonsDataFrame among many other possibilities.
+        </li>
+        <li>
+<a href="../packages/maptools/index.html">maptools</a>
+          provides conversion functions between
+<a href="../packages/PBSmapping/index.html">PBSmapping</a>
+          and
+<a href="../packages/spatstat/index.html">spatstat</a>
+          and
+<a href="../packages/sp/index.html">sp</a>
+          classes,
+      in addition to
+<a href="../packages/maps/index.html">maps</a>
+          databases and
+<a href="../packages/sp/index.html">sp</a>
+          classes.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Raster data
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/raster/index.html">raster</a>
+          package is a major extension of
+<a href="../packages/sp/index.html">sp</a>
+          spatial data 
+      classes to virtualise access to large rasters, permitting large 
+      objects to be analysed, and extending the analytical tools available 
+      for both raster and vector data. Used with
+<a href="../packages/rasterVis/index.html">rasterVis</a>, it
+      can also provide enhanced visualisation and interaction.
+        </li>
+        <li>
+<a href="../packages/stars/index.html">stars</a>
+          provides for spatiotemporal data in the form of dense arrays,
+      with space and time being array dimensions. Examples include socio-economic or
+      demographic data, environmental variables monitored at fixed stations, time series of
+      satellite images with multiple spectral bands, spatial simulations, and climate model
+      results.
+        </li>
+        <li>
+<a href="../packages/spatial.tools/index.html">spatial.tools</a>
+          package contains spatial functions meant to 
+      enhance the core functionality of the
+<a href="../packages/raster/index.html">raster</a>
+          package, 
+      including a parallel processing engine for use with rasters.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Geographic metadata
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/geometa/index.html">geometa</a>
+          provides classes and methods to write geographic
+        metadata following the ISO and OGC metadata standards (ISO 19115, 19110,
+        19119) and export it as XML (ISO 19139) for later publication into 
+        metadata catalogues. Reverserly, geometa provides a way to read ISO 19139
+        metadata into R. The package extends
+<a href="../packages/sf/index.html">sf</a>
+          to provide GML (ISO 19136)
+        representation of geometries. geometa is under active development on
+<a href="https://github.com/eblondel/geometa/"><span class="GitHub">geometa</span></a>
+        </li>
+        <li>
+<a href="../packages/ncdf4/index.html">ncdf4</a>
+          provides read and write functions for handling metadata
+        (CF conventions) in the self-described NetXDF format.
+        </li>
+      </ul>
+      <h2 id="reading-and-writing-spatial-data">
+        Reading and writing spatial data
+      </h2>
+      <p>
+        <strong>
+          Reading and writing spatial data -
+<a href="../packages/rgdal/index.html">rgdal</a>
+        </strong>
+      </p>
+      <p>
+        Maps may be vector-based or raster-based. The
+<a href="../packages/rgdal/index.html">rgdal</a>
+        package provides
+      bindings to
+        <a href="http://www.gdal.org/">
+          GDAL (Geospatial Data Abstraction Library)
+        </a>
+        -supported raster
+      formats and
+        <a href="http://www.gdal.org/ogr/">
+          OGR
+        </a>
+        -supported
+      vector formats. It contains functions to write raster and vector files in supported formats. Formats 
+      supported by GDAL/OGR include both OGC standard  data formats (e.g. GeoJSON) and 
+      proprietary formats (e.g. ESRI Shapefile).
+      The package also provides
+        <a href="https://proj4.org/">
+          PROJ.4
+        </a>
+        projection
+      support for vector objects 
+      (
+        <a href="http://spatialreference.org">
+          this site
+        </a>
+        provides 
+      searchable online PROJ.4 representations of projections). 
+      Affine and similarity transformations on sp objects may be made
+      using functions in the
+<a href="../packages/vec2dtransf/index.html">vec2dtransf</a>
+        package.
+      The Windows and Mac OSX CRAN binaries of
+<a href="../packages/rgdal/index.html">rgdal</a>
+        include subsets of possible data source drivers; if others
+      are needed, use other conversion utilities, or install from source
+      against a version of GDAL with the required drivers.
+      </p>
+      <p>
+        <strong>
+          Reading and writing spatial data - data formats
+        </strong>
+      </p>
+      <p>
+        Other packages provide facilities to read and write spatial data, dealing
+    with open standard formats or proprietary formats.
+      </p>
+      <p>
+        <em>
+          OGC Standard Data formats
+        </em>
+      </p>
+      <ul>
+        <li>
+          <em>
+            Well-Known Text (WKT) / Well-Known Binary (WKB):
+          </em>
+          These standards are
+        part of the OGC Simple Feature specification. Both WKT/WKB formats are supported by
+<a href="../packages/sf/index.html">sf</a>
+          package that
+        implements the whole OGC Simple Feature specification in R. Apart from the
+<a href="../packages/sf/index.html">sf</a>
+          package, the
+<a href="../packages/rgeos/index.html">rgeos</a>
+          package provides functions for reading and writing well-known text (WKT) geometry. 
+        Package
+<a href="../packages/wkb/index.html">wkb</a>
+          package provides functions for reading and writing well-known 
+        binary (WKB) geometry.
+        </li>
+        <li>
+          <em>
+            GeoJSON:
+          </em>
+          An rOpenSci
+          <a href="http://ropensci.org/blog/blog/2016/11/22/geospatial-suite">
+            blog entry
+          </a>
+          described a GeoJSON-centred approach to reading GeoJSON
+        and WKT data. GeoJSON can be written and read using
+<a href="../packages/rgdal/index.html">rgdal</a>, and
+        WKT by
+<a href="../packages/rgeos/index.html">rgeos</a>. The entry lists
+<a href="../packages/geojson/index.html">geojson</a>,
+<a href="../packages/geojsonio/index.html">geojsonio</a>,
+<a href="../packages/geoaxe/index.html">geoaxe</a>
+          and
+<a href="../packages/lawn/index.html">lawn</a>
+          among
+        others.
+        </li>
+        <li>
+          <em>
+            Geographic Markup Language (GML):
+          </em>
+          GML format can be read and writen with
+<a href="../packages/rgdal/index.html">rgdal</a>. Additional GML native reader and writer is provided by
+<a href="../packages/geometa/index.html">geometa</a>
+          model with bindings to the
+<a href="../packages/sf/index.html">sf</a>
+          classes, for extension of geographic 
+        metadata with GML data and metadata elements (GML 3.2.1 and 3.3) and interfacing OGC 
+        web-services in
+<a href="../packages/ows4R/index.html">ows4R</a>
+          package
+        </li>
+        <li>
+          <em>
+            NetCDF files:
+          </em>
+<a href="../packages/ncdf4/index.html">ncdf4</a>
+          or
+<a href="../packages/RNetCDF/index.html">RNetCDF</a>
+          may be used.
+        </li>
+      </ul>
+      <p>
+        <em>
+          Proprietary Data Formats
+        </em>
+      </p>
+      <ul>
+        <li>
+          <em>
+            ESRI formats:
+          </em>
+<a href="../packages/maps/index.html">maps</a>
+          (with
+<a href="../packages/mapdata/index.html">mapdata</a>
+          and
+<a href="../packages/mapproj/index.html">mapproj</a>)
+      provides access to the same kinds of geographical databases as S -
+<a href="../packages/RArcInfo/index.html">RArcInfo</a>
+          allows ArcInfo v.7 binary files and *.e00
+      files to be read, and
+<a href="../packages/maptools/index.html">maptools</a>
+          and
+<a href="../packages/shapefiles/index.html">shapefiles</a>
+          read and write ESRI ArcGIS/ArcView shapefiles.
+        </li>
+        <li>
+          <em>
+            Others:
+          </em>
+<a href="../packages/maptools/index.html">maptools</a>
+          package provides helper functions for writing map polygon
+      files to be read by
+          <em>
+            WinBUGS
+          </em>,
+          <em>
+            Mondrian
+          </em>, and the tmap command
+      in
+          <em>
+            Stata
+          </em>. The
+<a href="../packages/gmt/index.html">gmt</a>
+          package gives a simple interface between GMT
+      map-making software and R.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Reading and writing spatial data - GIS Software connectors
+        </strong>
+      </p>
+      <ul>
+        <li>
+          <em>
+            PostGIS:
+          </em>
+          The
+<a href="../packages/rpostgis/index.html">rpostgis</a>
+          package provides additional 
+      functions to the
+<a href="../packages/RPostgreSQL/index.html">RPostgreSQL</a>
+          package to interface R with 
+      a 'PostGIS'-enabled database, as well as convenient wrappers to common 
+      'PostgreSQL' queries. It is documented in an
+          <a href="https://journal.r-project.org/archive/2018/RJ-2018-025/index.html">
+            R Journal
+          </a>
+          article.
+<a href="../packages/postGIStools/index.html">postGIStools</a>
+          package provides functions 
+      to convert geometry and 'hstore' data types from 'PostgreSQL' into standard 
+      R objects, as well as to simplify the import of R data frames (including spatial
+      data frames) into 'PostgreSQL'.
+<a href="../packages/sf/index.html">sf</a>
+          also provides an R interface to 
+      Postgis, for both reading and writing, throuh GDAL.
+        </li>
+        <li>
+          <em>
+            GRASS:
+          </em>
+          Integration with version 7.* of the leading open source
+      GIS, GRASS, is provided in CRAN package
+<a href="../packages/rgrass7/index.html">rgrass7</a>, using
+<a href="../packages/rgdal/index.html">rgdal</a>
+          for exchanging data. 
+      For GRASS 6.*, use
+<a href="../packages/spgrass6/index.html">spgrass6</a>.
+        </li>
+        <li>
+          <em>
+            SAGA:
+          </em>
+<a href="../packages/RSAGA/index.html">RSAGA</a>
+          is a similar shell-based wrapper for SAGA commands.
+        </li>
+        <li>
+          <em>
+            Quantum GIS (QGIS):
+          </em>
+<a href="../packages/RQGIS/index.html">RQGIS</a>
+          package establishes an interface between R and QGIS, i.e. it allows
+      the user to access QGIS functionalities from the R console. It achieves
+      this by using the QGIS Python API via the command line. Note also
+          <a href="https://stat.ethz.ch/pipermail/r-sig-geo/2016-August/024817.html">
+            this thread
+          </a>
+          on an alternative R/QGIS integration.
+        </li>
+        <li>
+          <em>
+            ArcGIS:
+          </em>
+<a href="../packages/RPyGeo/index.html">RPyGeo</a>
+          is a wrapper
+      for Python access to the ArcGIS GeoProcessor
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Interfaces to Spatial Web-Services
+        </strong>
+      </p>
+      <p>
+        Some R packages focused on providing interfaces to web-services and web tools in support of 
+    spatial data management. Here follows a first tentative (non-exhaustive) list:
+      </p>
+      <ul>
+        <li>
+<a href="../packages/ows4R/index.html">ows4R</a>
+          is a new package that intends to provide an R interface 
+        to OGC standard Web-Services. It is in active development at
+<a href="https://github.com/eblondel/ows4R/"><span class="GitHub">ows4R</span></a>
+          and currently support interfaces to the Web Feature Service (WFS) for vector data access, 
+        with binding to the
+<a href="../packages/sf/index.html">sf</a>
+          package, and the Catalogue Service (CSW) for geographic 
+        metadata discovery and management (including transactions), with binding to the
+<a href="../packages/geometa/index.html">geometa</a>
+          package.
+        </li>
+        <li>
+<a href="../packages/geosapi/index.html">geosapi</a>
+          is an R client for the
+          <a href="http://geoserver.org">
+            GeoServer
+          </a>
+          REST API, 
+        an open source implementation used widely for serving spatial data.
+        </li>
+        <li>
+<a href="../packages/geonapi/index.html">geonapi</a>
+          provides an interface to the
+          <a href="https://geonetwork-opensource.org/">
+            GeoNetwork
+          </a>
+          legacy API, an opensource catalogue for managing geographic metadata.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Specific geospatial data sources of interest
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/rnaturalearth/index.html">rnaturalearth</a>
+          package facilitates interaction with
+          <a href="http://www.naturalearthdata.com/">
+            Natural Earth
+          </a>
+          map data.
+      It includes functions to download a wealth of Natural Earth vector and raster data, 
+      including cultural (e.g., country boundaries, airports, roads, railroads)
+      and physical (e.g., coastline, lakes, glaciates areas) datasets.
+        </li>
+        <li>
+          Modern country boundaries are
+      provided at 2 resolutions by
+<a href="../packages/rworldmap/index.html">rworldmap</a>
+          along with
+      functions to join and map tabular data referenced by country
+      names or codes. Chloropleth and bubble maps are supported and general
+      functions to work on user supplied maps (see
+          <a href="http://journal.r-project.org/archive/2011-1/RJournal_2011-1_South.pdf">
+            A New R package for Mapping Global Data
+          </a>. Higher resolution country
+      borders are available from the linked package
+<a href="../packages/rworldxtra/index.html">rworldxtra</a>.
+      Historical country boundaries (1946-2012) can be obtained from the
+<a href="../packages/cshapes/index.html">cshapes</a>.
+        </li>
+        <li>
+<a href="../packages/marmap/index.html">marmap</a>
+          package is designed for downloading, plotting 
+      and manipulating bathymetric and topographic data in R. It allows to
+      query the ETOPO1 bathymetry and topography database hosted by the
+      NOAA, use simple latitude-longitude-depth data in ascii format, and take
+      advantage of the advanced plotting tools available in R to build
+      publication-quality bathymetric maps (see the
+          <a href="http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0073051">
+            PLOS
+          </a>
+          paper).
+        </li>
+        <li>
+<a href="../packages/maptools/index.html">maptools</a>
+          provides an interface to GSHHS shoreline databases.
+        </li>
+        <li>
+          The UScensus2000 suite of packages (<a href="../packages/UScensus2000cdp/index.html">UScensus2000cdp</a>,
+<a href="../packages/UScensus2000tract/index.html">UScensus2000tract</a>) makes the
+      use of data from the 2000 US Census more convenient. An important
+      data set, Guerry's &quot;Moral Statistics of France&quot;, has been made
+      available in the
+<a href="../packages/Guerry/index.html">Guerry</a>
+          package, which provides data
+      and maps and examples designed to contribute to the integration
+      of multivariate and spatial analysis.
+        </li>
+        <li>
+<a href="../packages/rgbif/index.html">rgbif</a>
+          package is used to access Global
+      Biodiversity Information Facility (GBIF) occurence data
+        </li>
+        <li>
+<a href="../packages/geonames/index.html">geonames</a>
+          is an interface to 
+      the
+          <a href="http://www.geonames.org/">
+            www.geonames.org
+          </a>
+          service.
+        </li>
+        <li>
+<a href="../packages/OpenStreetMap/index.html">OpenStreetMap</a>
+          gives access to open street map raster images, 
+      and
+<a href="../packages/osmar/index.html">osmar</a>
+          provides infrastructure to access OpenStreetMap 
+      data from different sources, to work with the data in common R manner, 
+      and to convert data into available infrastructure provided by 
+      existing R packages.
+        </li>
+        <li>
+<a href="../packages/tidycensus/index.html">tidycensus</a>
+          provides access to US Census Bureau data in a tidy format,
+      including the option to bind the data spatially on import.
+        </li>
+        <li>
+<a href="../packages/tigris/index.html">tigris</a>
+          provides access to cartographic elements provided by the US
+      Census Bureau TIGER, including cartographic boundaries, roads, and water.
+        </li>
+      </ul>
+      <h2 id="handling-spatial-data">
+        Handling spatial data
+      </h2>
+      <p>
+        A number of packages dedicated to spatial data handling have been written
+    using sp classes.
+      </p>
+      <p>
+        <strong>
+          Data processing - general
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/rgdal/index.html">rgdal</a>
+          and
+<a href="../packages/maptools/index.html">maptools</a>. 
+      The
+<a href="../packages/rgeos/index.html">rgeos</a>
+          package provides an interface to topology functions
+      for
+<a href="../packages/sp/index.html">sp</a>
+          objects using
+          <a href="http://trac.osgeo.org/geos/">
+            GEOS
+          </a>.
+        </li>
+        <li>
+<a href="../packages/raster/index.html">raster</a>
+          package 
+      introduces many GIS methods that now permit much to be done with 
+      spatial data without having to use GIS in addition to R.
+        </li>
+        <li>
+          The
+<a href="../packages/gdalUtils/index.html">gdalUtils</a>
+          package provides wrappers for the Geospatial
+      Data Abstraction Library (GDAL) Utilities.
+        </li>
+        <li>
+<a href="../packages/gdistance/index.html">gdistance</a>, provides functions to calculate
+      distances and routes on geographic grids.
+<a href="../packages/geosphere/index.html">geosphere</a>
+          permits computations of distance and area 
+      to be carried out on spatial data in geographical coordinates.
+<a href="../packages/cshapes/index.html">cshapes</a>
+          package provides functions for calculating
+      distance matrices (see
+          <a href="http://journal.r-project.org/archive/2010-1/RJournal_2010-1_Weidmann+Skrede~Gleditsch.pdf">
+            Mapping and Measuring Country Shapes
+          </a>).
+        </li>
+        <li>
+<a href="../packages/spsurvey/index.html">spsurvey</a>
+          provides a range of sampling functions.
+        </li>
+        <li>
+          The
+<a href="../packages/trip/index.html">trip</a>
+          package extends sp
+      classes to permit the accessing and manipulating of spatial data for
+      animal tracking.
+        </li>
+        <li>
+<a href="../packages/spcosa/index.html">spcosa</a>
+          provides spatial coverage
+      sampling and random sampling from compact geographical strata.
+        </li>
+        <li>
+<a href="../packages/magclass/index.html">magclass</a>
+          offers a data class for increased
+      interoperability working with spatial-temporal data together with
+      corresponding functions and methods (conversions, basic calculations
+      and basic data manipulation). The class distinguishes between spatial,
+      temporal and other dimensions to facilitate the development and
+      interoperability of tools build for it. Additional features are
+      name-based addressing of data and internal consistency checks (e.g.
+      checking for the right data order in calculations).
+        </li>
+        <li>
+<a href="../packages/taRifx/index.html">taRifx</a>
+          is a collection of utility and 
+      convenience functions, and some interesting spatial functions.
+        </li>
+        <li>
+<a href="../packages/geoaxe/index.html">geoaxe</a>
+          allows users to split 'geospatial' objects into pieces.
+        </li>
+        <li>
+          The
+<a href="../packages/lawn/index.html">lawn</a>
+          package is a client for 'Turfjs' for 'geospatial'analysis.
+        </li>
+        <li>
+          The
+<a href="../packages/rcosmo/index.html">rcosmo</a>
+          package offers various tools for geometric transformations, 
+      computations, and statistical analysis of spherical data.
+        </li>
+        <li>
+          The
+<a href="../packages/areal/index.html">areal</a>
+          package can be used to interpolate overlapping but incongruent polygons,
+      also known as areal weighted interpolation.
+        </li>
+        <li>
+          The
+<a href="../packages/qualmap/index.html">qualmap</a>
+          package can be used to digitize qualitative GIS data.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Data processing - raster and imagery data
+        </strong>
+      </p>
+      <ul>
+        <li>
+          The
+<a href="../packages/landsat/index.html">landsat</a>
+          package with accompanying
+          <a href="http://www.jstatsoft.org/v43/i04">
+            JSS paper
+          </a>
+          provides
+      tools for exploring and developing correction tools for remote
+      sensing data.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Data cleaning
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/cleangeo/index.html">cleangeo</a>
+          may be used to 
+      inspect spatial objects, facilitate handling and reporting of topology 
+      errors and geometry validity issues. It may be used to reduce the likelihood 
+      of having issues when doing spatial data processing.
+        </li>
+        <li>
+<a href="../packages/lwgeom/index.html">lwgeom</a>
+          may also be used to 
+      facilitate handling and reporting of topology 
+      errors and geometry validity issues.
+        </li>
+      </ul>
+      <h2 id="visualizing-spatial-data">
+        Visualizing spatial data
+      </h2>
+      <p>
+        <strong>
+          Base visualization packages
+        </strong>
+      </p>
+      <ul>
+        <li>
+          Packages such as
+<a href="../packages/sp/index.html">sp</a>,
+<a href="../packages/sf/index.html">sf</a>,
+<a href="../packages/raster/index.html">raster</a>
+          and
+<a href="../packages/rasterVis/index.html">rasterVis</a>
+          provide basic visualization methods through the generic plot function
+        </li>
+        <li>
+<a href="../packages/RColorBrewer/index.html">RColorBrewer</a>
+          provides very useful colour palettes that may
+      be modified or extended using the
+<tt>colorRampPalette</tt>
+          function provided with R.
+        </li>
+        <li>
+<a href="../packages/viridis/index.html">viridis</a>
+          also provides colour palettes designed with consideration
+      for colorblindness and printing in grayscale.
+        </li>
+        <li>
+<a href="../packages/classInt/index.html">classInt</a>
+          package provides
+      functions for choosing class intervals for thematic cartography.
+        </li>
+        <li>
+<a href="../packages/rcosmo/index.html">rcosmo</a>
+          package provides several tools to interactively 
+      visualize HEALPix data, in particular, to plot data in 
+      arbitrary spherical windows.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Thematic cartography packages
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/tmap/index.html">tmap</a>
+          package provides a modern basis for thematic mapping
+      optionally using a Grammar of Graphics syntax. Because it has a custom
+      grid graphics platform, it obviates the need to fortify geometries to 
+      use with ggplot2.
+        </li>
+        <li>
+<a href="../packages/quickmapr/index.html">quickmapr</a>
+          provides a simple method to visualize 'sp' and 'raster' objects,
+      allows for basic zooming, panning, identifying, and labeling of
+      spatial objects, and does not require that the data be in geographic
+      coordinates.
+        </li>
+        <li>
+<a href="../packages/cartography/index.html">cartography</a>
+          package allows various
+      cartographic representations such as proportional symbols,
+      choropleth, typology, flows or discontinuities.
+        </li>
+        <li>
+          The
+<a href="../packages/mapmisc/index.html">mapmisc</a>
+          package is a minimal, light-weight set of tools for producing nice
+      looking maps in R, with support for map projections.
+        </li>
+        <li>
+          Additional processing and mapping functions are available in
+<a href="../packages/PBSmapping/index.html">PBSmapping</a>
+          package;
+<a href="../packages/PBSmodelling/index.html">PBSmodelling</a>
+          provides modelling support. In addition,
+<a href="../packages/GEOmap/index.html">GEOmap</a>
+          provides mapping facilities directed to meet the needs of geologists, and uses the
+<a href="../packages/geomapdata/index.html">geomapdata</a>
+          package.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Packages based on web-mapping frameworks
+        </strong>
+      </p>
+      <ul>
+        <li>
+<a href="../packages/mapview/index.html">mapview</a>,
+<a href="../packages/leaflet/index.html">leaflet</a>
+          and
+<a href="../packages/leafletR/index.html">leafletR</a>
+          packages provide methods to
+      view spatial objects interactively, usually on a web mapping base.
+        </li>
+        <li>
+<a href="../packages/RgoogleMaps/index.html">RgoogleMaps</a>
+          package for accessing 
+      Google Maps(TM) may be useful if the user wishes to place a map backdrop 
+      behind other displays.
+        </li>
+        <li>
+<a href="../packages/plotGoogleMaps/index.html">plotGoogleMaps</a>
+          package provides methods for the 
+      visualisation of spatial and spatio-temporal objects in Google Maps in
+      a web browser.
+        </li>
+        <li>
+<a href="../packages/plotKML/index.html">plotKML</a>
+          is a package providing methods for
+      the visualisation of spatial and spatio-temporal objects in Google
+      Earth.
+        </li>
+        <li>
+<a href="../packages/ggmap/index.html">ggmap</a>
+          may be used for spatial visualisation with Google Maps 
+      and OpenStreetMap;
+<a href="../packages/ggsn/index.html">ggsn</a>
+          provides North arrows and scales for such maps.
+        </li>
+        <li>
+<a href="../packages/mapedit/index.html">mapedit</a>
+          provides an R shiny widget based on
+<a href="../packages/leaflet/index.html">leaflet</a>
+          for editing or creating sf geometries.
+        </li>
+      </ul>
+      <p>
+        <strong>
+          Building Cartograms
+        </strong>
+      </p>
+      <ul>
+        <li>
+          The
+<a href="../packages/micromap/index.html">micromap</a>
+          package provides linked micromaps using ggplot2.
+        </li>
+        <li>
+<a href="../packages/recmap/index.html">recmap</a>
+          package provides rectangular 
+      cartograms with rectangle sizes reflecting for example population.
+        </li>
+        <li>
+<a href="../packages/statebins/index.html">statebins</a>
+          provides a simpler binning approach to US states.
+        </li>
+        <li>
+<a href="../packages/cartogram/index.html">cartogram</a>
+          package allows for constructions of a 
+      continuous area cartogram by a rubber sheet distortion algorithm, 
+      non-contiguous Area Cartograms, and non-overlapping Circles Cartogram.
+        </li>
+        <li>
+<a href="../packages/geogrid/index.html">geogrid</a>
+          package turns polygons into rectangular or 
+      hexagonal cartograms.
+        </li>
+      </ul>
+      <h2 id="analyzing-spatial-data">
+        Analyzing spatial data
+      </h2>
+      <p>
+        <strong>
+          Point pattern analysis
+        </strong>
+      </p>
+      <p>
+        The
+<a href="../packages/spatial/index.html">spatial</a>
+        package is a recommended package shipped with base R, and contains
+      several core functions, including an implementation of Khat
+      by its author, Prof. Ripley. In addition,
+<a href="../packages/spatstat/index.html">spatstat</a>
+        allows freedom in defining the region(s) of interest, and makes
+      extensions to marked processes and spatial covariates. Its
+      strengths are model-fitting and simulation, and it has a useful
+        <a href="http://www.spatstat.org/">
+          homepage
+        </a>. It is the only
+      package that will enable the user to fit inhomogeneous point process
+      models with interpoint interactions.
+      The
+<a href="../packages/spatgraphs/index.html">spatgraphs</a>
+        package provides graphs, graph visualisation and graph based
+      summaries to be used with spatial point pattern analysis. The
+<a href="../packages/splancs/index.html">splancs</a>
+        package also allows point data to be analysed
+      within a polygonal region of interest, and covers many methods,
+      including 2D kernel densities. The
+<a href="../packages/smacpod/index.html">smacpod</a>
+        package provides
+      various statistical methods for analyzing case-control point data.
+      The methods available closely follow those in chapter 6 of Applied
+      Spatial Statistics for Public Health Data by Waller and Gotway
+      (2004).
+      </p>
+      <p>
+<a href="../packages/ecespa/index.html">ecespa</a>
+        provides
+      wrappers, functions and data for spatial point pattern analysis,
+      used in the book on Spatial Ecology of the ECESPA/AEET. The
+      functions for binning points on grids in
+<a href="../packages/ash/index.html">ash</a>
+        may
+      also be of interest. The
+<a href="../packages/ads/index.html">ads</a>
+        package perform first-
+      and second-order multi-scale analyses derived from Ripley's
+      K-function. The
+<a href="../packages/aspace/index.html">aspace</a>
+        package is a collection of
+      functions for estimating centrographic statistics and computational
+      geometries from spatial point patterns.
+<a href="../packages/DSpat/index.html">DSpat</a>
+        contains functions for spatial modelling
+      for distance sampling data and
+<a href="../packages/spatialsegregation/index.html">spatialsegregation</a>
+        provides segregation measures for multitype spatial point 
+      patterns.
+<a href="../packages/GriegSmith/index.html">GriegSmith</a>
+        uses the Grieg-Smith method on 
+      2 dimensional spatial data. The
+<a href="../packages/dbmss/index.html">dbmss</a>
+        package allows 
+      simple computation of a full set of spatial statistic functions of 
+      distance, including classical ones (Ripley's K and others) and more 
+      recent ones used by spatial economists (Duranton and Overman's Kd, 
+      Marcon and Puech's M). It relies on spatstat for core 
+      calculation.
+<a href="../packages/latticeDensity/index.html">latticeDensity</a>
+        contains functions that compute
+      the lattice-based density estimator of Barry and McIntyre, which
+      accounts for point processes in two-dimensional regions with
+      irregular boundaries and holes.
+      </p>
+      <p>
+        <strong>
+          Geostatistics
+        </strong>
+      </p>
+      <p>
+        The
+<a href="../packages/gstat/index.html">gstat</a>
+        package
+      provides a wide range of functions for univariate and multivariate
+      geostatistics, also for larger datasets, while
+<a href="../packages/geoR/index.html">geoR</a>
+        and
+<a href="../packages/geoRglm/index.html">geoRglm</a>
+        contain functions for model-based
+      geostatistics. Variogram diagnostics may be carried out with
+<a href="../packages/vardiag/index.html">vardiag</a>. Automated interpolation using
+<a href="../packages/gstat/index.html">gstat</a>
+        is available in
+<a href="../packages/automap/index.html">automap</a>. This family of packages is
+      supplemented by
+<a href="../packages/intamap/index.html">intamap</a>
+        with procedures for automated
+      interpolation.  A similar wide range of
+      functions is to be found in the
+<a href="../packages/fields/index.html">fields</a>
+        package. The
+<a href="../packages/spatial/index.html">spatial</a>
+        package is shipped with base R, and contains
+      several core functions. The
+<a href="../packages/spBayes/index.html">spBayes</a>
+        package fits Gaussian
+      univariate and multivariate models with MCMC.
+<a href="../packages/ramps/index.html">ramps</a>
+        is a different Bayesian geostatistical modelling package.
+      The
+<a href="../packages/geospt/index.html">geospt</a>
+        package contains some geostatistical and radial
+      basis functions, including prediction and cross validation. Besides, 
+      it includes functions for the design of optimal spatial sampling 
+      networks based on geostatistical modelling.
+<a href="../packages/spsann/index.html">spsann</a>
+        is another
+      package to offer functions to optimize sample configurations, using
+      spatial simulated annealing. The
+<a href="../packages/geostatsp/index.html">geostatsp</a>
+        package offers geostatistical modelling facilities using Raster and
+      SpatialPoints objects are provided. Non-Gaussian models are fit
+      using INLA, and Gaussian geostatistical models use Maximum Likelihood
+      Estimation.  The
+<a href="../packages/rcosmo/index.html">rcosmo</a>
+        package offers various geostatistics
+      methods for spherical data: descriptive statistics, entropy based 
+      methods, covariance-variogram methods, etc. Most of rcosmo features 
+      were developed for Cosmic Microwave Background data, but they can 
+      also be used for any spherical data. The
+<a href="../packages/FRK/index.html">FRK</a>
+        package is a tool for 
+      spatial/spatio-temporal modelling and prediction with large datasets. 
+      The approach, discussed in Cressie and Johannesson (2008), decomposes
+      the field, and hence the covariance function, using a fixed set of n
+      basis functions, where n is typically much smaller than the number of
+      data points (or polygons) m.
+      </p>
+      <p>
+        The
+<a href="../packages/RandomFields/index.html">RandomFields</a>
+        package provides functions for
+      the simulation and analysis of random fields, and variogram
+      model descriptions can be passed between
+<a href="../packages/geoR/index.html">geoR</a>,
+<a href="../packages/gstat/index.html">gstat</a>
+        and this package.
+<a href="../packages/SpatialExtremes/index.html">SpatialExtremes</a>
+        proposes several approaches for spatial extremes modelling
+      using
+<a href="../packages/RandomFields/index.html">RandomFields</a>. In addition,
+<a href="../packages/CompRandFld/index.html">CompRandFld</a>,
+<a href="../packages/constrainedKriging/index.html">constrainedKriging</a>
+        and
+<a href="../packages/geospt/index.html">geospt</a>
+        provide 
+      alternative approaches to geostatistical modelling. The
+<a href="../packages/spTimer/index.html">spTimer</a>
+        package  is able to fit, spatially predict and 
+      temporally forecast large amounts of space-time data using [1] 
+      Bayesian Gaussian Process (GP) Models, [2] Bayesian Auto-Regressive 
+      (AR) Models, and [3] Bayesian Gaussian Predictive Processes (GPP) 
+      based AR Models. The
+<a href="../packages/rtop/index.html">rtop</a>
+        package provides functions for 
+      the geostatistical interpolation of data with irregular spatial 
+      support such as runoff related data or data from administrative 
+      units. The
+<a href="../packages/georob/index.html">georob</a>
+        package provides functions for fitting 
+      linear models with spatially correlated errors by robust and Gaussian 
+      Restricted Maximum Likelihood and for computing robust and customary 
+      point and block kriging predictions, along with utility functions for 
+      cross-validation and for unbiased back-transformation of kriging 
+      predictions of log-transformed data. The
+<a href="../packages/SpatialTools/index.html">SpatialTools</a>
+        package has an emphasis on kriging, and provides functions for 
+      prediction and simulation. It is extended by
+<a href="../packages/ExceedanceTools/index.html">ExceedanceTools</a>,
+      which provides tools for constructing confidence regions for exceedance
+      regions and contour lines. The
+<a href="../packages/gear/index.html">gear</a>
+        package implements
+      common geostatistical methods in a clean, straightforward, efficient
+      manner, and is said to be a quasi reboot of
+<a href="../packages/SpatialTools/index.html">SpatialTools</a>.
+      The
+<a href="../packages/sperrorest/index.html">sperrorest</a>
+        package implements spatial error estimation
+      and permutation-based spatial variable importance using different
+      spatial cross-validation and spatial block bootstrap methods.
+      The
+<a href="../packages/spm/index.html">spm</a>
+        package provides functions for hybrid geostatistical
+      and machine learning methods for spatial predictive modelling. It
+      currently contains two commonly used geostatistical methods, two machine
+      learning methods, four hybrid methods and two averaging methods.
+      </p>
+      <p>
+        The
+<a href="../packages/sgeostat/index.html">sgeostat</a>
+        package
+      is also available. Within the same general topical area are
+      the
+<a href="../packages/deldir/index.html">deldir</a>
+        and
+<a href="../packages/tripack/index.html">tripack</a>
+        packages for
+      triangulation and the
+<a href="../packages/akima/index.html">akima</a>
+        package for spline
+      interpolation; the
+<a href="../packages/MBA/index.html">MBA</a>
+        package provides scattered
+      data interpolation with multilevel B-splines. In addition,
+      there are the
+<a href="../packages/spatialCovariance/index.html">spatialCovariance</a>
+        package, which
+      supports the computation of spatial covariance matrices
+      for data on rectangles, the
+<a href="../packages/regress/index.html">regress</a>
+        package
+      building in part on
+<a href="../packages/spatialCovariance/index.html">spatialCovariance</a>, and the
+<a href="../packages/tgp/index.html">tgp</a>
+        package. The
+<a href="../packages/Stem/index.html">Stem</a>
+        package provides
+      for the estimation of the parameters of a spatio-temporal
+      model using the EM algorithm, and the estimation of the
+      parameter standard errors using a spatio-temporal parametric
+      bootstrap.
+<a href="../packages/FieldSim/index.html">FieldSim</a>
+        is another random fields
+      simulations package. The
+<a href="../packages/SSN/index.html">SSN</a>
+        is for geostatistical 
+      modeling for data on stream networks, including models based on 
+      in-stream distance. Models are created using moving average 
+      constructions. Spatial linear models, including covariates, can be 
+      fit with ML or REML. Mapping and other graphical functions are 
+      included. The
+<a href="../packages/ipdw/index.html">ipdw</a>
+        provides functions o interpolate 
+      georeferenced point data via Inverse Path Distance Weighting. Useful 
+      for coastal marine applications where barriers in the landscape 
+      preclude interpolation with Euclidean distances.
+<a href="../packages/RSurvey/index.html">RSurvey</a>
+        may be used as a processing program for spatially
+      distributed data, and is capable of error corrections and data
+      visualisation.
+      </p>
+      <p>
+        <strong>
+          Disease mapping and areal data analysis
+        </strong>
+      </p>
+      <p>
+<a href="../packages/DCluster/index.html">DCluster</a>
+        is a package for the detection of
+      spatial clusters of diseases. It extends and  depends on the
+<a href="../packages/spdep/index.html">spdep</a>
+        package, which provides basic functions for
+      building neighbour lists and spatial weights, tests for spatial
+      autocorrelation for areal data like Moran's I, and functions for
+      fitting spatial regression models, such as SAR and CAR models. These
+      models assume that the spatial dependence can be described by known
+      weights. In
+<a href="../packages/spdep/index.html">spdep</a>, the
+<tt>ME</tt>
+        and
+<tt>SpatialFiltering</tt>
+        functions provide Moran Eigenvector
+      model fitting, as do more modern functions in the
+<a href="../packages/spmoran/index.html">spmoran</a>
+        package. The
+<a href="../packages/SpatialEpi/index.html">SpatialEpi</a>
+        package provides implementations of
+      cluster detection and disease mapping functions, including Bayesian
+      cluster detection, and supports strata. The
+<a href="../packages/smerc/index.html">smerc</a>
+        package
+      provides statistical methods for the analysis of data areal data, with
+      a focus on cluster detection. The
+<a href="../packages/diseasemapping/index.html">diseasemapping</a>
+        package offers the formatting of population and case data, calculation
+      of Standardized Incidence Ratios, and fitting the BYM model using
+      INLA. Regionalisation of polygon
+      objects is provided by
+<a href="../packages/AMOEBA/index.html">AMOEBA</a>: a function to calculate
+      spatial clusters using the Getis-Ord local statistic. It searches
+      irregular clusters (ecotopes) on a map, and by
+<tt>skater</tt>
+        in
+<a href="../packages/spdep/index.html">spdep</a>. The
+<a href="../packages/seg/index.html">seg</a>
+        and
+<a href="../packages/OasisR/index.html">OasisR</a>
+        packages
+      provide functions for measuring spatial segregation;
+<a href="../packages/OasisR/index.html">OasisR</a>
+        includes Monte Carlo simulations to test the indices.
+      The
+<a href="../packages/spgwr/index.html">spgwr</a>
+        package contains an implementation of
+      geographically weighted regression methods for exploring possible
+      non-stationarity. The
+<a href="../packages/gwrr/index.html">gwrr</a>
+        package fits geographically
+      weighted regression (GWR) models and has tools to diagnose and 
+      remediate collinearity in the GWR models. Also fits geographically 
+      weighted ridge regression (GWRR) and geographically weighted lasso 
+      (GWL) models. The
+<a href="../packages/GWmodel/index.html">GWmodel</a>
+        package contains functions for 
+      computing geographically weighted (GW) models. Specifically, basic, 
+      robust, local ridge, heteroskedastic, mixed, multiscale, generalised 
+      and space-time GWR; GW summary statistics, GW PCA and GW discriminant analysis; 
+      associated tests and diagnostics; and options for a range of distance metrics. 
+      The
+<a href="../packages/lctools/index.html">lctools</a>
+        package provides researchers and educators with easy-to-learn user
+      friendly tools for calculating key spatial statistics and to apply
+      simple as well as advanced methods of spatial analysis in real data.
+      These include: Local Pearson and Geographically Weighted Pearson
+      Correlation Coefficients, Spatial Inequality Measures (Gini, Spatial
+      Gini, LQ, Focal LQ), Spatial Autocorrelation (Global and Local
+      Moran's I), several Geographically Weighted Regression techniques and
+      other Spatial Analysis tools (other geographically weighted statistics).
+      This package also contains functions for measuring the significance of
+      each statistic calculated, mainly based on Monte Carlo simulations.
+      The
+<a href="../packages/sparr/index.html">sparr</a>
+        package provides another
+      approach to relative risks. The
+<a href="../packages/CARBayes/index.html">CARBayes</a>
+        package 
+      implements Bayesian hierarchical spatial areal unit models. In 
+      such models, the spatial correlation is modelled by a set of random 
+      effects, which are assigned a conditional autoregressive (CAR) prior 
+      distribution. Examples of the models included are the BYM model as 
+      well as a recently developed localised spatial smoothing model.
+      The
+<a href="../packages/glmmBUGS/index.html">glmmBUGS</a>
+        package is a helpful way of passing out spatial
+      models to WinBUGS. The
+<a href="../packages/spaMM/index.html">spaMM</a>
+        package fits spatial GLMMs,
+      using the Matern correlation function as the basic model for spatial
+      random effects. The
+<a href="../packages/PReMiuM/index.html">PReMiuM</a>
+        package is for profile 
+      regression, which is a Dirichlet process Bayesian clustering model;
+      it provides a spatial CAR term that can be included in the fixed
+      effects (which are global, ie. non-cluster specific, parameters)
+      to account for any spatial correlation in the residuals.
+      The
+<a href="../packages/spacom/index.html">spacom</a>
+        package provides tools to
+      construct and exploit spatially weighted context data, and further
+      allows combining the resulting spatially weighted context data with
+      individual-level predictor and outcome variables, for the purposes
+      of multilevel modelling.
+      The
+<a href="../packages/geospacom/index.html">geospacom</a>
+        package generates
+      distance matrices from shape files and represents spatially weighted
+      multilevel analysis results. Spatial survival analysis is provided by
+      the
+<a href="../packages/spatsurv/index.html">spatsurv</a>
+        - Bayesian inference for parametric proportional
+      hazards spatial survival models - and
+<a href="../packages/spBayesSurv/index.html">spBayesSurv</a>
+        - Bayesian
+      Modeling and Analysis of Spatially Correlated Survival Data - packages.
+      The
+<a href="../packages/spselect/index.html">spselect</a>
+        package provides modelling functions based on
+      forward stepwise regression, incremental forward stagewise regression,
+      least angle regression (LARS), and lasso models for selecting the
+      spatial scale of covariates in regression models.
+      </p>
+      <p>
+        <strong>
+          Spatial regression
+        </strong>
+      </p>
+      <p>
+        The choice of function for spatial regression will depend on the 
+      support available. If the data are characterised by point support
+      and the spatial process is continuous, geostatistical methods may be 
+      used, or functions in the
+<a href="../packages/nlme/index.html">nlme</a>
+        package. If the support
+      is areal, and the spatial process is not being treated as continuous,
+      functions provided in the
+<a href="../packages/spdep/index.html">spdep</a>
+        package may be used.
+      This package can also be seen as providing spatial econometrics
+      functions, and, as noted above, provides basic functions for
+      building neighbour lists and spatial weights, tests for spatial
+      autocorrelation for areal data like Moran's I, and functions for
+      fitting spatial regression models. It provides the full range of
+      local indicators of spatial association, such as local Moran's I and
+      diagnostic tools for fitted linear models, including Lagrange
+      Multiplier tests. Spatial regression models that can be fitted using
+      maximum likelihood include spatial lag models, spatial error models,
+      and spatial Durbin models. For larger data sets, sparse matrix 
+      techniques can be used for maximum likelihood fits, while spatial 
+      two-stage least squares and generalised method of moments estimators are
+      an alternative. When using GMM,
+<a href="../packages/sphet/index.html">sphet</a>
+        can be used to 
+      accommodate both autocorrelation and heteroskedasticity.
+      The
+<a href="../packages/McSpatial/index.html">McSpatial</a>
+        provides functions 
+      for locally weighted regression, semiparametric and conditionally 
+      parametric regression, fourier and cubic spline functions, GMM and 
+      linearized spatial logit and probit, k-density functions and 
+      counterfactuals, nonparametric quantile regression and conditional 
+      density functions, Machado-Mata decomposition for quantile 
+      regressions, spatial AR model, repeat sales models, and 
+      conditionally parametric logit and probit.
+      The
+<a href="../packages/splm/index.html">splm</a>
+        package provides methods for 
+      fitting spatial panel data by maximum likelihood and GM. The two 
+      small packages
+<a href="../packages/S2sls/index.html">S2sls</a>
+        and
+<a href="../packages/spanel/index.html">spanel</a>
+        provide 
+      alternative implementations without most of the facilities of
+<a href="../packages/splm/index.html">splm</a>. The
+<a href="../packages/HSAR/index.html">HSAR</a>
+        package provides Hierarchical
+      Spatial Autoregressive Models (HSAR), based on a Bayesian Markov Chain
+      Monte Carlo (MCMC) algorithm.
+<a href="../packages/spatialprobit/index.html">spatialprobit</a>
+        make possible Bayesian estimation of the 
+      spatial autoregressive probit model (SAR probit model). The
+<a href="../packages/ProbitSpatial/index.html">ProbitSpatial</a>
+        package provides methods for fitting Binomial
+      spatial probit models to larger data sets; spatial autoregressive
+      (SAR) and spatial error (SEM) probit models are included. The
+<a href="../packages/starma/index.html">starma</a>
+        package provides functions to identify, estimate
+      and diagnose a Space-Time AutoRegressive Moving Average (STARMA)
+      model.
+      </p>
+      <p>
+        <strong>
+          Ecological analysis
+        </strong>
+      </p>
+      <p>
+        There are many packages for analysing ecological and environmental data. They include:
+      </p>
+      <ul>
+        <li>
+<a href="../packages/ade4/index.html">ade4</a>
+          for exploratory and Euclidean methods in the
+      environmental sciences,  the adehabitat family of packages 
+      for the analysis of habitat selection by animals
+      (<a href="../packages/adehabitatHR/index.html">adehabitatHR</a>,
+<a href="../packages/adehabitatHS/index.html">adehabitatHS</a>,
+<a href="../packages/adehabitatLT/index.html">adehabitatLT</a>, and
+<a href="../packages/adehabitatMA/index.html">adehabitatMA</a>)
+        </li>
+        <li>
+<a href="../packages/pastecs/index.html">pastecs</a>
+          for the
+      regulation, decomposition and analysis of space-time series
+        </li>
+        <li>
+<a href="../packages/vegan/index.html">vegan</a>
+          for ordination methods and other useful
+      functions for community and vegetation ecologists, and many
+      other functions in other contributed packages. One such is
+<a href="../packages/tripEstimation/index.html">tripEstimation</a>, basing on the classes provided by
+<a href="../packages/trip/index.html">trip</a>.
+<a href="../packages/ncf/index.html">ncf</a>
+          has entered CRAN recently, and
+      provides a range of spatial nonparametric covariance functions.
+        </li>
+        <li>
+          The
+<a href="../packages/spind/index.html">spind</a>
+          package provides functions for spatial methods
+      based on generalized estimating equations (GEE) and wavelet-revised
+      methods (WRM), functions for scaling by wavelet multiresolution
+      regression (WMRR), conducting multi-model inference, and stepwise model
+      selection.
+        </li>
+        <li>
+<a href="../packages/rangeMapper/index.html">rangeMapper</a>
+          is a package to manipulate species range
+      (extent-of-occurrence) maps, mainly tools for easy generation of
+      biodiversity (species richness) or life-history traits maps.
+        </li>
+        <li>
+          The
+<a href="../packages/siplab/index.html">siplab</a>
+          package is a platform for experimenting with
+      spatially explicit individual-based vegetation models.
+        </li>
+        <li>
+<a href="../packages/ModelMap/index.html">ModelMap</a>
+          builds on other packages to create models
+      using underlying GIS data.
+        </li>
+        <li>
+          The
+<a href="../packages/SpatialPosition/index.html">SpatialPosition</a>
+          computes
+      spatial position models: Stewart potentials, Reilly catchment areas,
+      Huff catchment areas.
+        </li>
+        <li>
+          The
+<a href="../packages/Watersheds/index.html">Watersheds</a>
+          package provides
+      methods for watersheds aggregation and spatial drainage network
+      analysis.
+        </li>
+        <li>
+          <a href="http://www.leg.ufpr.br/Rcitrus/">
+            Rcitrus
+          </a>
+          (off-CRAN package)
+      is for the spatial analysis of plant disease incidence.
+        </li>
+        <li>
+          The
+<a href="../packages/ngspatial/index.html">ngspatial</a>
+          package 
+      provides tools for analyzing spatial data, especially non-Gaussian 
+      areal data. It supports the sparse spatial generalized linear mixed 
+      model of Hughes and Haran (2013) and the centered autologistic model 
+      of Caragea and Kaiser (2009).
+        </li>
+        <li>
+<a href="../packages/landscapemetrics/index.html">landscapemetrics</a>
+          package calculates landscape metrics 
+      for categorical landscape patterns. It can be used as a drop-in replacement for
+          <a href="https://www.umass.edu/landeco/research/fragstats/fragstats.html">
+            FRAGSTATS
+          </a>, 
+      as it offers a reproducible workflow for landscape analysis in a single environment. 
+      It also provides several visualization functions, e.g.
+      to show all labeled patches or the core area of all patches.
+        </li>
+      </ul>
+      <p>
+        The
+        <a href="Environmetrics.html">
+          Environmetrics
+        </a>
+        Task View contains 
+    a much more complete survey of relevant functions and packages.
+      </p>
+    </div>
+
+  <h3>CRAN packages:</h3>
+  <ul>
+    <li><a href="../packages/ade4/index.html">ade4</a></li>
+    <li><a href="../packages/adehabitatHR/index.html">adehabitatHR</a></li>
+    <li><a href="../packages/adehabitatHS/index.html">adehabitatHS</a></li>
+    <li><a href="../packages/adehabitatLT/index.html">adehabitatLT</a></li>
+    <li><a href="../packages/adehabitatMA/index.html">adehabitatMA</a></li>
+    <li><a href="../packages/ads/index.html">ads</a></li>
+    <li><a href="../packages/akima/index.html">akima</a></li>
+    <li><a href="../packages/AMOEBA/index.html">AMOEBA</a></li>
+    <li><a href="../packages/areal/index.html">areal</a></li>
+    <li><a href="../packages/ash/index.html">ash</a></li>
+    <li><a href="../packages/aspace/index.html">aspace</a></li>
+    <li><a href="../packages/automap/index.html">automap</a></li>
+    <li><a href="../packages/CARBayes/index.html">CARBayes</a></li>
+    <li><a href="../packages/cartogram/index.html">cartogram</a></li>
+    <li><a href="../packages/cartography/index.html">cartography</a></li>
+    <li><a href="../packages/classInt/index.html">classInt</a> (core)</li>
+    <li><a href="../packages/cleangeo/index.html">cleangeo</a></li>
+    <li><a href="../packages/CompRandFld/index.html">CompRandFld</a></li>
+    <li><a href="../packages/constrainedKriging/index.html">constrainedKriging</a></li>
+    <li><a href="../packages/cshapes/index.html">cshapes</a></li>
+    <li><a href="../packages/dbmss/index.html">dbmss</a></li>
+    <li><a href="../packages/DCluster/index.html">DCluster</a> (core)</li>
+    <li><a href="../packages/deldir/index.html">deldir</a> (core)</li>
+    <li><a href="../packages/diseasemapping/index.html">diseasemapping</a></li>
+    <li><a href="../packages/DSpat/index.html">DSpat</a></li>
+    <li><a href="../packages/ecespa/index.html">ecespa</a></li>
+    <li><a href="../packages/ExceedanceTools/index.html">ExceedanceTools</a></li>
+    <li><a href="../packages/fields/index.html">fields</a></li>
+    <li><a href="../packages/FieldSim/index.html">FieldSim</a></li>
+    <li><a href="../packages/FRK/index.html">FRK</a></li>
+    <li><a href="../packages/gdalUtils/index.html">gdalUtils</a></li>
+    <li><a href="../packages/gdistance/index.html">gdistance</a></li>
+    <li><a href="../packages/gear/index.html">gear</a></li>
+    <li><a href="../packages/geoaxe/index.html">geoaxe</a></li>
+    <li><a href="../packages/geogrid/index.html">geogrid</a></li>
+    <li><a href="../packages/geojson/index.html">geojson</a></li>
+    <li><a href="../packages/geojsonio/index.html">geojsonio</a></li>
+    <li><a href="../packages/GEOmap/index.html">GEOmap</a></li>
+    <li><a href="../packages/geomapdata/index.html">geomapdata</a></li>
+    <li><a href="../packages/geometa/index.html">geometa</a></li>
+    <li><a href="../packages/geonames/index.html">geonames</a></li>
+    <li><a href="../packages/geonapi/index.html">geonapi</a></li>
+    <li><a href="../packages/geoR/index.html">geoR</a> (core)</li>
+    <li><a href="../packages/geoRglm/index.html">geoRglm</a></li>
+    <li><a href="../packages/georob/index.html">georob</a></li>
+    <li><a href="../packages/geosapi/index.html">geosapi</a></li>
+    <li><a href="../packages/geospacom/index.html">geospacom</a></li>
+    <li><a href="../packages/geosphere/index.html">geosphere</a></li>
+    <li><a href="../packages/geospt/index.html">geospt</a></li>
+    <li><a href="../packages/geostatsp/index.html">geostatsp</a></li>
+    <li><a href="../packages/ggmap/index.html">ggmap</a></li>
+    <li><a href="../packages/ggsn/index.html">ggsn</a></li>
+    <li><a href="../packages/glmmBUGS/index.html">glmmBUGS</a></li>
+    <li><a href="../packages/gmt/index.html">gmt</a></li>
+    <li><a href="../packages/GriegSmith/index.html">GriegSmith</a></li>
+    <li><a href="../packages/gstat/index.html">gstat</a> (core)</li>
+    <li><a href="../packages/Guerry/index.html">Guerry</a></li>
+    <li><a href="../packages/GWmodel/index.html">GWmodel</a></li>
+    <li><a href="../packages/gwrr/index.html">gwrr</a></li>
+    <li><a href="../packages/HSAR/index.html">HSAR</a></li>
+    <li><a href="../packages/igraph/index.html">igraph</a></li>
+    <li><a href="../packages/inlmisc/index.html">inlmisc</a></li>
+    <li><a href="../packages/intamap/index.html">intamap</a></li>
+    <li><a href="../packages/ipdw/index.html">ipdw</a></li>
+    <li><a href="../packages/landsat/index.html">landsat</a></li>
+    <li><a href="../packages/landscapemetrics/index.html">landscapemetrics</a></li>
+    <li><a href="../packages/latticeDensity/index.html">latticeDensity</a></li>
+    <li><a href="../packages/lawn/index.html">lawn</a></li>
+    <li><a href="../packages/lctools/index.html">lctools</a></li>
+    <li><a href="../packages/leaflet/index.html">leaflet</a></li>
+    <li><a href="../packages/leafletR/index.html">leafletR</a></li>
+    <li><a href="../packages/lwgeom/index.html">lwgeom</a></li>
+    <li><a href="../packages/magclass/index.html">magclass</a></li>
+    <li><a href="../packages/mapdata/index.html">mapdata</a></li>
+    <li><a href="../packages/mapedit/index.html">mapedit</a></li>
+    <li><a href="../packages/mapmisc/index.html">mapmisc</a></li>
+    <li><a href="../packages/mapproj/index.html">mapproj</a></li>
+    <li><a href="../packages/maps/index.html">maps</a></li>
+    <li><a href="../packages/maptools/index.html">maptools</a> (core)</li>
+    <li><a href="../packages/mapview/index.html">mapview</a></li>
+    <li><a href="../packages/marmap/index.html">marmap</a></li>
+    <li><a href="../packages/MBA/index.html">MBA</a></li>
+    <li><a href="../packages/McSpatial/index.html">McSpatial</a></li>
+    <li><a href="../packages/micromap/index.html">micromap</a></li>
+    <li><a href="../packages/ModelMap/index.html">ModelMap</a></li>
+    <li><a href="../packages/ncdf4/index.html">ncdf4</a></li>
+    <li><a href="../packages/ncf/index.html">ncf</a></li>
+    <li><a href="../packages/ngspatial/index.html">ngspatial</a></li>
+    <li><a href="../packages/nlme/index.html">nlme</a></li>
+    <li><a href="../packages/OasisR/index.html">OasisR</a></li>
+    <li><a href="../packages/OpenStreetMap/index.html">OpenStreetMap</a></li>
+    <li><a href="../packages/osmar/index.html">osmar</a></li>
+    <li><a href="../packages/ows4R/index.html">ows4R</a></li>
+    <li><a href="../packages/pastecs/index.html">pastecs</a></li>
+    <li><a href="../packages/PBSmapping/index.html">PBSmapping</a></li>
+    <li><a href="../packages/PBSmodelling/index.html">PBSmodelling</a></li>
+    <li><a href="../packages/plotGoogleMaps/index.html">plotGoogleMaps</a></li>
+    <li><a href="../packages/plotKML/index.html">plotKML</a></li>
+    <li><a href="../packages/postGIStools/index.html">postGIStools</a></li>
+    <li><a href="../packages/PReMiuM/index.html">PReMiuM</a></li>
+    <li><a href="../packages/ProbitSpatial/index.html">ProbitSpatial</a></li>
+    <li><a href="../packages/qualmap/index.html">qualmap</a></li>
+    <li><a href="../packages/quickmapr/index.html">quickmapr</a></li>
+    <li><a href="../packages/ramps/index.html">ramps</a></li>
+    <li><a href="../packages/RandomFields/index.html">RandomFields</a> (core)</li>
+    <li><a href="../packages/rangeMapper/index.html">rangeMapper</a></li>
+    <li><a href="../packages/RArcInfo/index.html">RArcInfo</a></li>
+    <li><a href="../packages/raster/index.html">raster</a> (core)</li>
+    <li><a href="../packages/rasterVis/index.html">rasterVis</a></li>
+    <li><a href="../packages/RColorBrewer/index.html">RColorBrewer</a> (core)</li>
+    <li><a href="../packages/rcosmo/index.html">rcosmo</a></li>
+    <li><a href="../packages/recmap/index.html">recmap</a></li>
+    <li><a href="../packages/regress/index.html">regress</a></li>
+    <li><a href="../packages/rgbif/index.html">rgbif</a></li>
+    <li><a href="../packages/rgdal/index.html">rgdal</a> (core)</li>
+    <li><a href="../packages/rgeos/index.html">rgeos</a> (core)</li>
+    <li><a href="../packages/RgoogleMaps/index.html">RgoogleMaps</a></li>
+    <li><a href="../packages/rgrass7/index.html">rgrass7</a></li>
+    <li><a href="../packages/rnaturalearth/index.html">rnaturalearth</a></li>
+    <li><a href="../packages/RNetCDF/index.html">RNetCDF</a></li>
+    <li><a href="../packages/rpostgis/index.html">rpostgis</a></li>
+    <li><a href="../packages/RPostgreSQL/index.html">RPostgreSQL</a></li>
+    <li><a href="../packages/RPyGeo/index.html">RPyGeo</a></li>
+    <li><a href="../packages/RQGIS/index.html">RQGIS</a></li>
+    <li><a href="../packages/RSAGA/index.html">RSAGA</a></li>
+    <li><a href="../packages/RSurvey/index.html">RSurvey</a></li>
+    <li><a href="../packages/rtop/index.html">rtop</a></li>
+    <li><a href="../packages/rworldmap/index.html">rworldmap</a></li>
+    <li><a href="../packages/rworldxtra/index.html">rworldxtra</a></li>
+    <li><a href="../packages/S2sls/index.html">S2sls</a></li>
+    <li><a href="../packages/seg/index.html">seg</a></li>
+    <li><a href="../packages/sf/index.html">sf</a> (core)</li>
+    <li><a href="../packages/sgeostat/index.html">sgeostat</a></li>
+    <li><a href="../packages/shapefiles/index.html">shapefiles</a></li>
+    <li><a href="../packages/shp2graph/index.html">shp2graph</a></li>
+    <li><a href="../packages/siplab/index.html">siplab</a></li>
+    <li><a href="../packages/smacpod/index.html">smacpod</a></li>
+    <li><a href="../packages/smerc/index.html">smerc</a></li>
+    <li><a href="../packages/sp/index.html">sp</a> (core)</li>
+    <li><a href="../packages/spacetime/index.html">spacetime</a> (core)</li>
+    <li><a href="../packages/spacom/index.html">spacom</a></li>
+    <li><a href="../packages/spaMM/index.html">spaMM</a></li>
+    <li><a href="../packages/spanel/index.html">spanel</a></li>
+    <li><a href="../packages/sparr/index.html">sparr</a></li>
+    <li><a href="../packages/spatgraphs/index.html">spatgraphs</a></li>
+    <li><a href="../packages/spatial/index.html">spatial</a></li>
+    <li><a href="../packages/spatial.tools/index.html">spatial.tools</a></li>
+    <li><a href="../packages/spatialCovariance/index.html">spatialCovariance</a></li>
+    <li><a href="../packages/SpatialEpi/index.html">SpatialEpi</a></li>
+    <li><a href="../packages/SpatialExtremes/index.html">SpatialExtremes</a></li>
+    <li><a href="../packages/SpatialPosition/index.html">SpatialPosition</a></li>
+    <li><a href="../packages/spatialprobit/index.html">spatialprobit</a></li>
+    <li><a href="../packages/spatialsegregation/index.html">spatialsegregation</a></li>
+    <li><a href="../packages/SpatialTools/index.html">SpatialTools</a></li>
+    <li><a href="../packages/spatstat/index.html">spatstat</a> (core)</li>
+    <li><a href="../packages/spatsurv/index.html">spatsurv</a></li>
+    <li><a href="../packages/spBayes/index.html">spBayes</a></li>
+    <li><a href="../packages/spBayesSurv/index.html">spBayesSurv</a></li>
+    <li><a href="../packages/spcosa/index.html">spcosa</a></li>
+    <li><a href="../packages/spdep/index.html">spdep</a> (core)</li>
+    <li><a href="../packages/sperrorest/index.html">sperrorest</a></li>
+    <li><a href="../packages/spgrass6/index.html">spgrass6</a></li>
+    <li><a href="../packages/spgwr/index.html">spgwr</a></li>
+    <li><a href="../packages/sphet/index.html">sphet</a></li>
+    <li><a href="../packages/spind/index.html">spind</a></li>
+    <li><a href="../packages/splancs/index.html">splancs</a> (core)</li>
+    <li><a href="../packages/splm/index.html">splm</a></li>
+    <li><a href="../packages/spm/index.html">spm</a></li>
+    <li><a href="../packages/spmoran/index.html">spmoran</a></li>
+    <li><a href="../packages/spsann/index.html">spsann</a></li>
+    <li><a href="../packages/spselect/index.html">spselect</a></li>
+    <li><a href="../packages/spsurvey/index.html">spsurvey</a></li>
+    <li><a href="../packages/spTimer/index.html">spTimer</a></li>
+    <li><a href="../packages/SSN/index.html">SSN</a></li>
+    <li><a href="../packages/starma/index.html">starma</a></li>
+    <li><a href="../packages/stars/index.html">stars</a></li>
+    <li><a href="../packages/statebins/index.html">statebins</a></li>
+    <li><a href="../packages/Stem/index.html">Stem</a></li>
+    <li><a href="../packages/stplanr/index.html">stplanr</a></li>
+    <li><a href="../packages/taRifx/index.html">taRifx</a></li>
+    <li><a href="../packages/tgp/index.html">tgp</a></li>
+    <li><a href="../packages/tidycensus/index.html">tidycensus</a></li>
+    <li><a href="../packages/tigris/index.html">tigris</a></li>
+    <li><a href="../packages/tmap/index.html">tmap</a></li>
+    <li><a href="../packages/trip/index.html">trip</a></li>
+    <li><a href="../packages/tripack/index.html">tripack</a></li>
+    <li><a href="../packages/tripEstimation/index.html">tripEstimation</a></li>
+    <li><a href="../packages/UScensus2000cdp/index.html">UScensus2000cdp</a></li>
+    <li><a href="../packages/UScensus2000tract/index.html">UScensus2000tract</a></li>
+    <li><a href="../packages/vardiag/index.html">vardiag</a></li>
+    <li><a href="../packages/vec2dtransf/index.html">vec2dtransf</a></li>
+    <li><a href="../packages/vegan/index.html">vegan</a></li>
+    <li><a href="../packages/viridis/index.html">viridis</a></li>
+    <li><a href="../packages/Watersheds/index.html">Watersheds</a></li>
+    <li><a href="../packages/wkb/index.html">wkb</a></li>
+  </ul>
+
+  <h3>Related links:</h3>
+  <ul>
+    <li>CRAN Task View: <a href="SpatioTemporal.html">SpatioTemporal</a></li>
+    <li>CRAN Task View: <a href="Environmetrics.html">Environmetrics</a></li>
+    <li><a href="https://stat.ethz.ch/mailman/listinfo/R-SIG-Geo/">
+  R-SIG-Geo mailing list
+</a></li>
+  </ul>
+
+</body>
+</html>

--- a/ctv/Spatial.ctv
+++ b/ctv/Spatial.ctv
@@ -70,7 +70,7 @@
       <a href="http://CRAN.R-project.org/doc/Rnews/Rnews_2005-2.pdf">R
       News</a>.</li>  
       <li><pkg>sf</pkg> is a newer package now on CRAN, and is being
-      actively developed here: <github>rspatial/sf</github>,
+      actively developed here: <github>r-spatial/sf</github>,
       providing Simple Features for R, in compliance with the 
       <a href="http://www.opengeospatial.org/standards/sfa">OGC Simple Feature</a> standard. 
       The development of the package is being supported by the 
@@ -272,6 +272,10 @@
       data from different sources, to work with the data in common R manner, 
       and to convert data into available infrastructure provided by 
       existing R packages.</li>
+      <li><pkg>tidycensus</pkg> provides access to US Census Bureau data in a tidy format,
+      including the option to bind the data spatially on import. </li>
+      <li><pkg>tigris</pkg> provides access to cartographic elements provided by the US
+      Census Bureau TIGER, including cartographic boundaries, roads, and water.</li>
     </ul>
     
     <h2 id="handling-spatial-data">Handling spatial data</h2>  
@@ -315,6 +319,9 @@
       <li>The <pkg>lawn</pkg> package is a client for 'Turfjs' for 'geospatial'analysis.</li>
       <li>The <pkg>rcosmo</pkg> package offers various tools for geometric transformations, 
       computations, and statistical analysis of spherical data.</li>
+      <li>The <pkg>areal</pkg> package can be used to interpolate overlapping but incongruent polygons,
+      also known as areal weighted interpolation.</li>
+      <li>The <pkg>qualmap</pkg> package can be used to digitize qualitative GIS data.</li>
     </ul>      
         
     <p><strong>Data processing - raster and imagery data</strong></p>    
@@ -345,6 +352,8 @@
       <li><pkg>RColorBrewer</pkg> provides very useful colour palettes that may
       be modified or extended using the <code>colorRampPalette</code>
       function provided with R.</li>
+      <li><pkg>viridis</pkg> also provides colour palettes designed with consideration
+      for colorblindness and printing in grayscale.</li>
       <li><pkg>classInt</pkg> package provides
       functions for choosing class intervals for thematic cartography.</li>
       <li><pkg>rcosmo</pkg> package provides several tools to interactively 
@@ -390,6 +399,7 @@
       Earth.</li>
       <li><pkg>ggmap</pkg> may be used for spatial visualisation with Google Maps 
       and OpenStreetMap;<pkg>ggsn</pkg> provides North arrows and scales for such maps.</li>
+      <li><pkg>mapedit</pkg> provides an R shiny widget based on <pkg>leaflet</pkg> for editing or creating sf geometries.</li>
     </ul>
     
     <p><strong>Building Cartograms</strong></p>    
@@ -743,6 +753,7 @@
     <pkg>ads</pkg>
     <pkg>akima</pkg>
     <pkg>AMOEBA</pkg>
+    <pkg>areal</pkg>
     <pkg>aspace</pkg>
     <pkg>ash</pkg>
     <pkg>automap</pkg>
@@ -808,6 +819,7 @@
     <pkg>lwgeom</pkg>
     <pkg>magclass</pkg>
     <pkg>mapdata</pkg>
+    <pkg>mapedit</pkg>
     <pkg>mapmisc</pkg>
     <pkg>mapproj</pkg>
     <pkg>maps</pkg>
@@ -913,6 +925,8 @@
     <pkg>stplanr</pkg>
     <pkg>taRifx</pkg>
     <pkg>tgp</pkg>
+    <pkg>tidycensus</pkg>
+    <pkg>tigris</pkg>
     <pkg>trip</pkg>
     <pkg>tripEstimation</pkg>
     <pkg>tripack</pkg>
@@ -922,8 +936,10 @@
     <pkg>vardiag</pkg>
     <pkg>vec2dtransf</pkg>
     <pkg>vegan</pkg>
+    <pkg>viridis</pkg>
     <pkg>Watersheds</pkg>
     <pkg>wkb</pkg>
+    <pkg>qualmap</pkg>
   </packagelist>
 
     


### PR DESCRIPTION
This pull request achieves the following:

* Fixes the `sf` GitHub URL
* Adds these packages `tidycensus`,`tigris`,`areal`,`qualmap`,`viridis`,`mapedit`

Both the HTML formatting and that all packages are in the package list has been verified.