### PR TITLE
add {rgugik} to Spatial Task View

### DIFF
--- a/ctv/Spatial.ctv
+++ b/ctv/Spatial.ctv
@@ -298,6 +298,8 @@
       Uruguay.</li>
       <li><pkg>RCzechia</pkg> downloads spatial shape files of administrative 
       regions and other spatial objects of the Czech Republic.</li>
+      <li><pkg>rgugik</pkg> allows to search and retrieve data from Polish Head
+      Office of Geodesy and Cartography ("GUGiK").</li>
     </ul>
     
     <h2 id="handling-spatial-data">Handling spatial data</h2>  
@@ -865,6 +867,7 @@
     <pkg priority="core">rgeos</pkg>
     <pkg>RgoogleMaps</pkg>
     <pkg>rgrass7</pkg>
+    <pkg>rgugik</pkg>
     <pkg>rnaturalearth</pkg>
     <pkg>RNetCDF</pkg>
     <pkg>RPostgreSQL</pkg>


### PR DESCRIPTION
Here is a proposal to add [rgugik](https://cran.r-project.org/web/packages/rgugik/index.html) to Spatial Task View. This package is mainly used to search and retrieve open data from Polish Head Office of Geodesy and Cartography ("[Główny Urząd Geodezji i Kartografii](http://www.gugik.gov.pl/)").